### PR TITLE
Fixes a typo in cfndsl.rb that was causing an error when in verbose mode...

### DIFF
--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -70,11 +70,11 @@ module CfnDsl
         end
 
       when :ruby
-        logstream("Runnning ruby file #{file}") if logstream
+        logstream.puts("Runnning ruby file #{file}") if logstream
         b.eval(File.read(file), file)
 
       when :raw
-        logstrame("Running raw ruby code #{file}") if logstream
+        logstream.puts("Running raw ruby code #{file}") if logstream
         b.eval(file, "raw code")
       end
     end


### PR DESCRIPTION
.... Also adding in missing .puts() calls against a couple logstream usages.

The 'logstrame' typo caused the following error when running with the -v flag:

![image](https://cloud.githubusercontent.com/assets/1060638/5654070/09effdea-9714-11e4-8953-73f756f93a38.png)

Without the missing '.puts' against the logstream objects, the following error is encountered:

![image](https://cloud.githubusercontent.com/assets/1060638/5654016/921586b4-9713-11e4-8913-a645f511e956.png)