### PR TITLE
Alert user if they've incorrectly capitialized the function name

### DIFF
--- a/lib/cfndsl/JSONable.rb
+++ b/lib/cfndsl/JSONable.rb
@@ -176,14 +176,23 @@ module CfnDsl
       self.instance_eval &block if block_given?
     end
 
-    def method_missing(meth,*args,&block)
-      if(args) then
-        arg = "(" + args.inspect[1..-2] + ")"
-      else
-        arg = ""
-      end
-      CfnDsl::Errors.error( "Undefined symbol: #{meth}#{arg}", 1 )
+    def method_missing(meth, *args, &block)
+      error = "Undefined symbol: #{meth}"
+      error = "#{error}(" + args.inspect[1..-2] + ")" unless args.empty?
+      error = "#{error}\n\nTry '#{titleize(meth)}' instead" if incorrect_capitalization?(meth)
+      CfnDsl::Errors.error(error, 1)
     end
+
+    def incorrect_capitalization?(method)
+      method != titleize(method) && respond_to?(titleize(method))
+    end
+
+    def titleize(method)
+      method.to_s.clone.tap do |m|
+        m[0] = m[0,1].upcase
+      end.to_sym
+    end
+
   end
 
 


### PR DESCRIPTION
Currently when the user has a template with a function name and it's incorrectly capitalised they'll be told the symbol doesn't exits.

This PR adds a little bit of extra output to let the user know they should try the capitalised version.

This arose from an issue someone had: https://github.com/stevenjack/cfndsl/issues/82