### PR TITLE
Adding support for LoadBalancer Policies

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -342,6 +342,7 @@ Resources:
     ConnectionDrainingPolicy: ConnectionDrainingPolicy
     ConnectionSettings: ConnectionSettings
     LoadBalancerName: String
+    Policies: [ ElasticLoadBalancingPolicy ]
    Attributes:
     CanonicalHostedZoneName: String
     CanonicalGostedZoneNameID: String
@@ -820,3 +821,9 @@ Types:
    ResourcePath: String
    SearchString: String
    Type: String
+ ElasticLoadBalancingPolicy:
+   Attributes: [ JSON ]
+   InstancePorts: [ String ]
+   LoadBalancerPorts: [ String ]
+   PolicyName: String
+   PolicyType: String


### PR DESCRIPTION
Adding support for LoadBalancer Policies.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-policy.html#cfn-ec2-elb-policy-policytype

and

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html