### PR TITLE
updating the properties for route53 hosted zones

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -561,6 +561,8 @@ Resources:
    Properties:
     HostedZoneConfig: Route53HostedZoneConfig
     Name: String
+    VPCs: [ HostedZoneVPC ]
+    HostedZoneTags: [ HostedZoneTag ]
   "AWS::Route53::HealthCheck" :
    Properties:
     HealthCheckConfig: Route53HealthCheckConfig
@@ -707,6 +709,12 @@ Types:
   Target: String
   Timeout: String
   UnhealthyThreshold: String
+ HostedZoneVPC:
+  VPCId:
+  VPCRegion: String
+ HostedZoneTag:
+  Key: String
+  Value: String
  LBCookieStickinessPolicy:
   CookieExpirationPeriod: String
   PolicyName: String


### PR DESCRIPTION
Added some of the additional properties to the HostedZone to bring it into line with: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-hostedzone.html