### PR TITLE
Added ElastiCache Replication Group support.

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -297,6 +297,26 @@ Resources:
     PreferredAvailabilityZone: String
     PreferredMaintenanceWindow: String
     VpcSecurityGroupIds: [String]
+  "AWS::ElastiCache::ReplicationGroup" :
+   Properties:
+    AutomaticFailoverEnabled: Boolean
+    AutoMinorVersionUpgrade: Boolean
+    CacheNodeType: String
+    CacheParameterGroupName: String
+    CacheSecurityGroupNames: [String]
+    CacheSubnetGroupName: String
+    Engine: String
+    EngineVersion: String
+    NotificationTopicArn: String
+    NumCacheClusters: Integer
+    Port: Integer
+    PreferredCacheClusterAZs: [String]
+    PreferredMaintenanceWindow: String
+    ReplicationGroupDescription: String
+    SecurityGroupIds: [String]
+    SnapshotArns: [String]
+    SnapshotRetentionLimit: Integer
+    SnapshotWindow: String
   "AWS::ElastiCache::ParameterGroup" :
     Properties:
      CacheParameterGroupFamily: String


### PR DESCRIPTION
Hi there,

This is just a small PR to add support for ElastiCache Replication Groups added by AWS recently: [Announcement Link](http://aws.amazon.com/about-aws/whats-new/2015/06/aws-cloudformation-updates-support-for-elasticache-s3-iam-rds/)

Let me know if you require any changes.

Thanks.