### PR TITLE
[READY] Adds gem release based on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,19 @@
 language: ruby
 rvm:
-  - 2.1.0
+- 2.1.0
 sudo: false
 
+deploy:
+  provider: rubygems
+  api_key:
+    secure: AH+4R+m6U0kmALFYAYEQl2oF/dj1yOnu/M1ZOtWttk+Zjwnw6kFc0hFLbvxdy6uivq1XmMXVa9eXzDPsRjW4ow2g+UuDLxvkvfT45SMmJ5sYQpoiD7AIJnEvMu6TXnmfiRNgM5bHnV3oilNJ8KKCbCFCd+imGRLTkBuhLkhkejA=
+  gem: cfndsl
+  on:
+    tags: true
+    repo: stevenjack/cfndsl
+notifications:
+  email:
+    recipients:
+      - stevenmajack@gmail.com
+    on_failure: change
+    on_success: never


### PR DESCRIPTION
### Dependencies

* https://github.com/stevenjack/cfndsl/pull/102

### Problem

Currently every time you want to release a new version of a gem you need to check the repository out and run `rake release`. I would like this to be automated.

### Solution

Use the built in [deployment functionality](http://docs.travis-ci.com/user/deployment/rubygems/) travis offers to push the gem up based on a tag from this repo.