### PR TITLE
[READY] Update to be inline with bundler gemspec format

### DIFF
--- a/cfndsl.gemspec
+++ b/cfndsl.gemspec
@@ -1,34 +1,21 @@
-Gem::Specification.new do |s|
-  s.name        = 'cfndsl'
-  s.version     = '0.1.16'
-  s.summary     = "AWS Cloudformation DSL"
-  s.description = "DSL for creating AWS Cloudformation templates"
-  s.authors     = ['Steven Jack', 'Chris Howe']
-  s.email       = ['stevenmajack@gmail.com', 'chris@howeville.com']
-  s.files       = [ "lib/cfndsl.rb",
-                    "lib/cfndsl/aws_types.yaml",
-                    "lib/cfndsl/os_types.yaml",
-                    "lib/cfndsl/JSONable.rb",
-                    "lib/cfndsl/module.rb",
-                    "lib/cfndsl/RefCheck.rb",
-                    "lib/cfndsl/Types.rb",
-                    'lib/cfndsl/Properties.rb',
-                    'lib/cfndsl/Conditions.rb',
-                    'lib/cfndsl/Mappings.rb',
-                    'lib/cfndsl/Resources.rb',
-                    'lib/cfndsl/Metadata.rb',
-                    'lib/cfndsl/Parameters.rb',
-                    'lib/cfndsl/Outputs.rb',
-                    'lib/cfndsl/Errors.rb',
-                    'lib/cfndsl/Plurals.rb',
-                    'lib/cfndsl/names.rb',
-                    'lib/cfndsl/CloudFormationTemplate.rb',
-        'lib/cfndsl/CreationPolicy.rb',
-                    'lib/cfndsl/UpdatePolicy.rb'
-                  ]
-  s.executables = ['cfndsl']
-  s.homepage    = 'https://github.com/stevenjack/cfndsl'
-  s.license     = 'MIT'
+# coding: utf-8
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "cfndsl/version"
 
-  s.add_development_dependency 'bundler'
+Gem::Specification.new do |s|
+  s.name                    = "cfndsl"
+  s.version                 = CfnDsl::VERSION
+  s.summary                 = "AWS Cloudformation DSL"
+  s.description             = "DSL for creating AWS Cloudformation templates"
+  s.authors                 = ["Steven Jack", "Chris Howe"]
+  s.email                   = ["stevenmajack@gmail.com", "chris@howeville.com"]
+  s.files                   = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  s.executables             << "cfndsl"
+  s.homepage                = "https://github.com/stevenjack/cfndsl"
+  s.license                 = "MIT"
+  s.test_files              = s.files.grep(%r{^(test|spec|features)/})
+  s.require_paths           = ["lib"]
+
+  s.add_development_dependency "bundler"
 end

--- a/lib/cfndsl/version.rb
+++ b/lib/cfndsl/version.rb
@@ -1,0 +1,3 @@
+module CfnDsl
+  VERSION = "0.1.16"
+end


### PR DESCRIPTION
### Problem

The gem spec doesn't follow the same spec as the one's usually created by bundler (The spec was created before bundler did this). This means if new files are added you need to remember to include them in the spec and if the version changes you update it in here rather than a version file.

### Solution

Mimic the setup of the bundler spec.