### PR TITLE
[READY] Adds task for bumping version number

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,55 @@
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+require "cfndsl/version"
+
 RSpec::Core::RakeTask.new
 
 task default: [:spec]
 
+task :bump, :type do |t, args|
+  type = args[:type].downcase
+  version_path = "lib/cfndsl/version.rb"
 
+  fail unless %w(major minor patch).include? type
 
+  if `git rev-parse --abbrev-ref HEAD` != "master"
+    fail "Looks like you're trying to create a release in a branch, you can only create one in 'master'"
+  end
 
+  version_segments = CfnDsl::VERSION.split(".").map(&:to_i)
+
+  case type
+  when "major"
+    version_segments[0]+= 1
+    version_segments[1] = 0
+    version_segments[2] = 0
+  when "minor"
+    version_segments[1]+= 1
+    version_segments[2] = 0
+  when "patch"
+    version_segments[2]+= 1
+  end
+
+  version = version_segments.join(".")
+
+  puts "Bumping gem from version #{CfnDsl::VERSION} to #{version} as a '#{type.capitalize}' release"
+
+  contents         = File.read version_path
+  updated_contents = contents.gsub(/([0-9\.]+)/, version)
+  File.write(version_path, updated_contents)
+
+  puts "Commiting version update"
+  `git add #{version_path}`
+  `git commit --message='#{type.capitalize} release #{version}'`
+
+  puts "Tagging release"
+  `git tag -a v#{version} -m 'Version #{version}'`
+
+  puts "Pushing branch"
+  `git push origin master`
+
+  puts "Pushing tag"
+  `git push origin v#{version}`
+
+  puts "All done, travis should pick up and release the gem now!"
+end


### PR DESCRIPTION
### Problem

Currently you need to manually bump the version number, commit the changes, tag the branch and push everything up. This should be automated.

### Solution

Add a rake task that does these steps for you, by supplying the type of server release (Major/Minor/Patch) the version will be updated accordingly, a tag created and everything pushed up.

#### Example

```bash
$: rake bump\[patch\]
Bumping gem from version 0.1.16 to 0.1.17 as a 'Patch' release
Commiting version update
Tagging release
Pushing branch
Pushing tag
All done, travis should pick up and release the gem now!
```