### PR TITLE
added rake task with ability to specify multiple templates to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ maintain:
 
 * All structures are JSON, so it is sometimes easy for a person
   reading a template to get lost.
-  
+
 * References and internal functions have a particularly unpleasant syntax.
 
 
@@ -25,26 +25,26 @@ templates by running ruby.
 ## Getting Started
 
     sudo gem install cfndsl
-	
+
 Now write a template in the dsl
-   
+
 ```ruby
 
 CloudFormation {
   Description "Test"
-  
+
   Parameter("One") {
     String
     Default "Test"
 	MaxLength 15
   }
- 
+
   Output(:One,FnBase64( Ref("One")))
 
   EC2_Instance(:MyInstance) {
     ImageId "ami-12345678"
   }
-  
+
 }
 ```
 
@@ -88,12 +88,12 @@ this gem was done on a [Raspberry Pi](http://www.raspberrypi.org).*
 ## Samples
 
 There is a more detailed example in the samples directory. The file
-"autoscale.template" is one of the standard Amazon sample templates. 
+"autoscale.template" is one of the standard Amazon sample templates.
 "autoscale.rb" generates an equivalent template file.
 
 ## Command Line Options
 
-The cfndsl command line program now accepts some command line options. 
+The cfndsl command line program now accepts some command line options.
 
 ```
 Usage: cfndsl [options] FILE
@@ -106,18 +106,18 @@ Usage: cfndsl [options] FILE
     -h, --help                       Display this screen
 ```
 
-By default, cfndsl will attempt to evaluate FILE as cfndsl template and print 
+By default, cfndsl will attempt to evaluate FILE as cfndsl template and print
 the resulting cloudformation json template to stdout. With the -o option, you
-can instead have it write the resulting json template to a given file. The -v 
+can instead have it write the resulting json template to a given file. The -v
 option prints out additional information (to stderr) about what is happening
-in the model generation process. 
+in the model generation process.
 
 The -y, -j, -r and -D options can be used to control some things about the
 environment that the template code gets evaluate in. For instance, the -D
-option allows you to set a variable at the command line that can then be 
+option allows you to set a variable at the command line that can then be
 referred to within the template itself.
 
-This is best illustrated with a example. Consider the following cfndsl 
+This is best illustrated with a example. Consider the following cfndsl
 template
 
 ```ruby
@@ -136,7 +136,7 @@ CloudFormation {
       Type "t1.micro"
     }
   end
-  
+
 }
 ```
 
@@ -196,7 +196,7 @@ you get the following generated template.
 ```
 
 The -y and -j options allow you to group several variable definitions
-into a single file (formated as either yaml or ruby respectively). If 
+into a single file (formated as either yaml or ruby respectively). If
 you had a file called 't1.yaml' that contained the following,
 
 ```yaml
@@ -215,7 +215,29 @@ would generate a template with 5 instances declared.
 
 Finally, the -r option gives you the opportunity to execute some
 arbitrary ruby code in the evaluation context before the cloudformation
-template is evaluated. 
+template is evaluated.
 
+### Rake task
+Simply add the following to your `Rakefile`:
 
+```ruby
+require 'cfndsl/rake_task'
 
+CfnDsl::RakeTask.new do |t|
+  t.cfndsl_opts = {
+    files: [{
+      filename: 'templates/application.rb',
+      output: 'application.json'
+    }],
+    extras: [{
+      yaml: 'templates/default_params.yml'
+    }]
+  }
+end
+```
+
+And then use rake to generate the cloudformation:
+
+```bash
+$ bin/rake generate
+```

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,9 @@ task :bump, :type do |t, args|
   type = args[:type].downcase
   version_path = "lib/cfndsl/version.rb"
 
-  fail unless %w(major minor patch).include? type
+  types = %w[major minor patch]
+
+  fail unless types.include? type
 
   if `git rev-parse --abbrev-ref HEAD`.strip != "master"
     fail "Looks like you're trying to create a release in a branch, you can only create one in 'master'"
@@ -18,17 +20,11 @@ task :bump, :type do |t, args|
 
   version_segments = CfnDsl::VERSION.split(".").map(&:to_i)
 
-  case type
-  when "major"
-    version_segments[0]+= 1
-    version_segments[1] = 0
-    version_segments[2] = 0
-  when "minor"
-    version_segments[1]+= 1
-    version_segments[2] = 0
-  when "patch"
-    version_segments[2]+= 1
-  end
+  segment_index = types.find_index type
+
+  version_segments = version_segments.take(segment_index) +
+                     [version_segments.at(segment_index).succ] +
+                     [0] * version_segments.drop(segment_index.succ).count
 
   version = version_segments.join(".")
 

--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -285,6 +285,7 @@ Resources:
   "AWS::ElastiCache::CacheCluster" :
    Properties:
     AutoMinorVersionUpgrade: Boolean
+    ClusterName: String
     CacheNodeType: String
     CacheParameterGroupName: String
     CacheSecurityGroupNames: [String]

--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -233,6 +233,7 @@ Resources:
     VpcId: String
     CidrBlock: String
     Tags: [ EC2Tag ]
+    MapPublicIpOnLaunch: Boolean
   "AWS::EC2::SubnetRouteTableAssociation" :
    Properties:
     SubnetId: String

--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -643,6 +643,7 @@ Resources:
   "AWS::SQS::Queue" :
     Properties:
      VisibilityTimeout: String
+     QueueName: String
     Attributes:
      Arn: String
      QueueName: String

--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -196,6 +196,7 @@ Resources:
     InstanceId: String
     NetworkInterfaceId: String
     RouteTableId: String
+    VpcPeeringConnectionId: String
   "AWS::EC2::RouteTable" :
    Properties:
     VpcId: String

--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -404,6 +404,7 @@ Resources:
   "AWS::IAM::Role" :
    Properties:
     AssumeRolePolicyDocument: JSON
+    ManagedPolicyArns: [ String ]
     Path: String
     Policies: [ IAMEmbeddedPolicy ]
    Attributes:

--- a/lib/cfndsl/rake_task.rb
+++ b/lib/cfndsl/rake_task.rb
@@ -1,31 +1,53 @@
-require 'rake'
-require 'rake/tasklib'
-require 'cfndsl'
+require "rake"
+require "rake/tasklib"
+require "cfndsl"
 
 module CfnDsl
   class RakeTask < Rake::TaskLib
     attr_accessor :cfndsl_opts
 
-
     def initialize(name = nil)
       yield self if block_given?
 
-      desc 'Generate Cloudformation' unless ::Rake.application.last_comment
-      task(name || :generate) do |t, args|
+      desc "Generate Cloudformation" unless ::Rake.application.last_comment
+      task(name || :generate) do |_t, _args|
         cfndsl_opts[:files].each do |opts|
-          extra = cfndsl_opts[:extras] || []
-          verbose = cfndsl_opts[:verbose] && STDERR
-          model = CfnDsl::eval_file_with_extras(opts[:filename], extra, verbose)
-          if opts[:output].nil?
-            verbose.puts("Writing to STDOUT") if verbose
-            STDOUT.puts model.to_json
-          else
-            verbose.puts("Writing to #{opts[:output]}") if verbose
-            output = File.open( File.expand_path(opts[:output]), "w")
-            output.puts model.to_json
-          end
+          generate(opts)
         end
       end
+    end
+
+    private
+
+    def generate(opts)
+      log(opts)
+      outputter(opts).puts model(opts[:filename])
+    end
+
+    def log(opts)
+      type = opts[:output].nil? ? "STDOUT" : opts[:output]
+      verbose.puts("Writing to #{type}") if verbose
+    end
+
+    def outputter(opts)
+      opts[:output].nil? ? STDOUT : file_output(opts[:output])
+    end
+
+    def model(filename)
+      fail "#{filename} doesn't exist" unless File.exist? filename
+      CfnDsl.eval_file_with_extras(filename, extra, verbose).to_json
+    end
+
+    def extra
+      cfndsl_opts.fetch(:extras, [])
+    end
+
+    def verbose
+      cfndsl_opts[:verbose] && STDERR
+    end
+
+    def file_output(path)
+      File.open(File.expand_path(path), "w")
     end
   end
 end

--- a/lib/cfndsl/rake_task.rb
+++ b/lib/cfndsl/rake_task.rb
@@ -1,0 +1,31 @@
+require 'rake'
+require 'rake/tasklib'
+require 'cfndsl'
+
+module CfnDsl
+  class RakeTask < Rake::TaskLib
+    attr_accessor :cfndsl_opts
+
+
+    def initialize(name = nil)
+      yield self if block_given?
+
+      desc 'Generate Cloudformation' unless ::Rake.application.last_comment
+      task(name || :generate) do |t, args|
+        cfndsl_opts[:files].each do |opts|
+          extra = cfndsl_opts[:extras] || []
+          verbose = cfndsl_opts[:verbose] && STDERR
+          model = CfnDsl::eval_file_with_extras(opts[:filename], extra, verbose)
+          if opts[:output].nil?
+            verbose.puts("Writing to STDOUT") if verbose
+            STDOUT.puts model.to_json
+          else
+            verbose.puts("Writing to #{opts[:output]}") if verbose
+            output = File.open( File.expand_path(opts[:output]), "w")
+            output.puts model.to_json
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cfndsl/version.rb
+++ b/lib/cfndsl/version.rb
@@ -1,3 +1,3 @@
 module CfnDsl
-  VERSION = "0.1.19"
+  VERSION = "0.1.20"
 end

--- a/lib/cfndsl/version.rb
+++ b/lib/cfndsl/version.rb
@@ -1,3 +1,3 @@
 module CfnDsl
-  VERSION = "0.1.18"
+  VERSION = "0.1.19"
 end


### PR DESCRIPTION
### Problem

Most projects consist of a number of templates/stacks and wiring these up when generating each template is time consuming and error prone.

### Solution

Adds a rake task that can be included in your projects rake task and you can select the `template`, `extras` files and optionally output it to a file.