### PR TITLE
adding a VPCPeeringConnectionID to routes

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -196,6 +196,7 @@ Resources:
     InstanceId: String
     NetworkInterfaceId: String
     RouteTableId: String
+    VpcPeeringConnectionId: String
   "AWS::EC2::RouteTable" :
    Properties:
     VpcId: String


### PR DESCRIPTION
Adding support for the VPCPeeringConnectionId to the routes type.