### PR TITLE
Add MapPublicIpOnLaunch property to Subnet resource

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -233,6 +233,7 @@ Resources:
     VpcId: String
     CidrBlock: String
     Tags: [ EC2Tag ]
+    MapPublicIpOnLaunch: Boolean
   "AWS::EC2::SubnetRouteTableAssociation" :
    Properties:
     SubnetId: String


### PR DESCRIPTION
The subnet property `MapPublicIpOnLaunch` allows a subnet to automatically assign a public ip to instances