### PR TITLE
Default FnNot to an array

### DIFF
--- a/lib/cfndsl/JSONable.rb
+++ b/lib/cfndsl/JSONable.rb
@@ -66,7 +66,7 @@ module CfnDsl
     def FnNot(value)
       ##
       # Equivalent to the Cloudformation template built in function Fn::Not
-      Fn.new("Not", value)
+      Fn.new("Not", [value].flatten.compact)
     end
 
     def FnOr(array)

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -100,6 +100,21 @@ describe CfnDsl::CloudFormationTemplate do
       expect(refs).to have_key('X')
     end
 
+    context 'FnNot' do
+      let(:data) { "test" }
+      let(:expected) { "{\"Fn::Not\":[\"#{data}\"]}" }
+
+      it 'formats correctly' do
+        func = subject.FnNot data
+        expect(func.to_json).to eq expected
+      end
+
+      it 'flattens existing array' do
+        func = subject.FnNot [data]
+        expect(func.to_json).to eq expected
+      end
+    end
+
     it 'FnBase64' do
       func = subject.FnBase64 'A'
       expect(func.to_json).to eq('{"Fn::Base64":"A"}')


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/stevenjack/cfndsl/issues/90, the default behaviour for the `FnNot` function is to wrap the second argument in an array:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html

### Solution

Wrap the argument in an array, then flatten it incase it already is an array and remove any `nil` elements.

