### PR TITLE
Updated AWS Types for VPN, VPC Peering, and Autoscaling resources

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -33,6 +33,15 @@ Resources:
      SecurityGroups: [ String ]
      SpotPrice: String
      UserData: String
+  "AWS::AutoScaling::LifecycleHook" :
+   Properties:
+    AutoScalingGroupName : String
+    DefaultResult : String
+    HeartbeatTimeout : Integer
+    LifecycleTransition : String
+    NotificationMetadata : String
+    NotificationTargetARN : String
+    RoleARN : String
   "AWS::AutoScaling::ScalingPolicy" :
    Properties:
     AdjustmentType: String
@@ -284,6 +293,37 @@ Resources:
     InternetGatewayId: String
     VpcId: String
     VpnGatewayId: String
+  "AWS::EC2::VPCPeeringConnection" :
+   Properties:
+    PeerVpcId : String
+    Tags : [ EC2Tag ]
+    VpcId : String
+  "AWS::EC2::VPNGateway" :
+   Properties:
+    Type : String
+    Tags : [ EC2Tag ]
+  "AWS::EC2::VPNGatewayConnection" :
+   Properties:
+    Type : String
+    CustomerGatewayId : String
+    StaticRoutesOnly : Boolean
+    Tags : [ EC2Tag ]
+    VpnGatewayId : String
+  "AWS::EC2::VPNConnection" :
+   Properties:
+    Type : String
+    CustomerGatewayId : String
+    StaticRoutesOnly : Boolean
+    Tags : [ EC2Tag ]
+    VpnGatewayId : String
+  "AWS::EC2::VPNConnectionRoute" :
+   Properties:
+    DestinationCidrBlock : String
+    VpnConnectionId : String
+  "AWS::EC2::VPNGatewayRoutePropagation" :
+   Properties:
+    RouteTableIds : [ String ]
+    VpnGatewayId : String
   "AWS::ElastiCache::CacheCluster" :
    Properties:
     AutoMinorVersionUpgrade: Boolean

--- a/sample/vpc-with-vpn-example.rb
+++ b/sample/vpc-with-vpn-example.rb
@@ -1,0 +1,97 @@
+require 'cfndsl'
+
+CloudFormation {
+  Description "Creates an AWS VPC with a couple of subnets."
+
+  Parameter("VPNAddress") {
+    Type "String"
+    Description "IP Address range for your existing infrastructure"
+    MinLength "9"
+    MaxLength "18"
+    AllowedPattern "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
+    ConstraintDescription "must be a valid IP CIDR range of the form x.x.x.x/x."
+  }
+
+  Parameter("RouterIPAddress") {
+    Type "String"
+    Description "IP Address of your VPN device"
+    MinLength "7"
+    MaxLength "15"
+    AllowedPattern "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    ConstraintDescription "must be a valid IP address of the form x.x.x.x"    
+  }
+
+  VPC(:VPC) {
+    EnableDnsSupport true
+    EnableDnsHostnames true
+    CidrBlock "10.1.0.0/16"
+    addTag("Name", "Test VPC")
+  }
+
+  InternetGateway(:InternetGateway) {
+    addTag("Name", "Test VPC Gateway")
+  }
+
+  VPCGatewayAttachment(:GatewayToInternet) {
+    VpcId Ref(:VPC)
+    InternetGatewayId  Ref(:InternetGateway)
+  }
+
+  10.times do |i|
+    subnet = "subnet#{i}"
+    route_table = subnet + "RouteTable"
+    route_table_assoc = route_table + "Assoc"
+
+    Subnet(subnet) {
+      VpcId Ref(:VPC)
+      CidrBlock "10.1.#{i}.0/24"
+      addTag("Name", "test vpc #{subnet}")
+    }
+
+    RouteTable(route_table) {
+      VpcId Ref(:VPC)
+      addTag("Name", route_table)
+    }
+
+    SubnetRouteTableAssociation(route_table_assoc) {
+      SubnetId Ref(subnet)
+      RouteTableId Ref(route_table)
+    }
+
+    Route(subnet + "GatewayRoute" ) {
+      DependsOn :GatewayToInternet
+      RouteTableId Ref(route_table)
+      DestinationCidrBlock "0.0.0.0/0"
+      GatewayId Ref(:InternetGateway)
+    }
+  end
+
+  VPNGateway(:VirtualPrivateNetworkGateway) {
+    Type "ipsec.1"
+    addTag("Name", "Test VPN Gateway")
+  }
+
+  VPCGatewayAttachment(:VPNGatewayAttachment) {
+    VpcId Ref(:VPC)
+    VpnGatewayId Ref(:VirtualPrivateNetworkGateway)
+  }
+
+  CustomerGateway(:CustomerVPNGateway) {
+    Type "ipsec.1"
+    BgpAsn "65000"
+    IpAddress Ref("RouterIPAddress")
+    addTag("Name", "Test Customer VPN Gateway")
+  }
+
+  VPNConnection(:VPNConnection) {
+    Type "ipsec.1"
+    StaticRoutesOnly "true"
+    CustomerGatewayId Ref(:CustomerVPNGateway)
+    VpnGatewayId Ref(:VirtualPrivateNetworkGateway)
+  }
+
+  VPNConnectionRoute(:VPNConnectionRoute) {
+    VpnConnectionId Ref(:VPNConnection)
+    DestinationCidrBlock Ref("VPNAddress")
+  }
+}


### PR DESCRIPTION
with VPC and VPN examples

* AWS::AutoScaling::LifecycleHook
* AWS::EC2::VPCPeeringConnection
* AWS::EC2::VPNGateway
* AWS::EC2::VPNGatewayConnection
* AWS::EC2::VPNConnection
* AWS::EC2::VPNConnectionRoute
* AWS::EC2::VPNGatewayRoutePropagation