### PR TITLE
Support RDS replicas.

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -554,6 +554,7 @@ Resources:
      PreferredMaintenanceWindow: String
      PubliclyAccessible: String
      MultiAZ: Boolean
+     SourceDBInstanceIdentifier: String
      Tags: [ EC2Tag ]
      VPCSecurityGroups: [ String ]
     Attributes:


### PR DESCRIPTION
Per http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html

Adding `SourceDBInstanceIdentifier` allows provisioning of replica databases.