### PR TITLE
Ensure last value wins when a Property is set multiple times

### DIFF
--- a/lib/cfndsl/CloudFormationTemplate.rb
+++ b/lib/cfndsl/CloudFormationTemplate.rb
@@ -90,7 +90,7 @@ module CfnDsl
                   values.push create_klass.new
                 end
                 @Properties ||= {}
-                @Properties[pname] ||= CfnDsl::PropertyDefinition.new( *values )
+                @Properties[pname] = CfnDsl::PropertyDefinition.new( *values )
                 @Properties[pname].value.instance_eval &block if block
                 @Properties[pname].value
               end
@@ -192,7 +192,7 @@ module CfnDsl
                   values.push create_klass.new
                 end
                 @Properties ||= {}
-                @Properties[pname] ||= CfnDsl::PropertyDefinition.new( *values )
+                @Properties[pname] = CfnDsl::PropertyDefinition.new( *values )
                 @Properties[pname].value.instance_eval &block if block
                 @Properties[pname].value
               end

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -1,5 +1,19 @@
 require 'spec_helper'
 
+describe CfnDsl::HeatTemplate do
+  it 'honors last-set value for non-array properties' do
+    spec = self
+    subject.declare do
+      Server('myserver') do
+        flavor 'foo'
+        flavor 'bar'
+        f = @Properties['flavor'].value
+        spec.expect(f).to spec.eq('bar')
+      end
+    end
+  end
+end
+
 describe CfnDsl::CloudFormationTemplate do
 
   it 'populates an empty template' do
@@ -79,6 +93,18 @@ describe CfnDsl::CloudFormationTemplate do
       expect(ref.to_json).to eq("{\"Ref\":\"#{param}\"}")
       refs = ref.references({})
       expect(refs).to have_key(param)
+    end
+  end
+
+  it 'honors last-set value for non-array properties' do
+    spec = self
+    subject.declare do
+      EC2_Instance('myserver') do
+        InstanceType 'foo'
+        InstanceType 'bar'
+        f = @Properties['InstanceType'].value
+        spec.expect(f).to spec.eq('bar')
+      end
     end
   end
 


### PR DESCRIPTION
This allows overrides in different code modules.

A test case:

    require 'cfndsl'                                                                                                                                

    template = CfnDsl::HeatTemplate.new
    instance = template.Server('fooserver')
    instance.declare {
      flavor "foo"
      flavor "bar"
    }
    template

I expect the instance to have flavor "bar", but it actually has "foo".  Currently later properties cannot override earlier ones. 