### PR TITLE
Add support for VPCEndpoint resources

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -305,6 +305,12 @@ Resources:
    Properties:
     DhcpOptionsId: String
     VpcId: String
+  "AWS::EC2::VPCEndpoint" :
+   Properties:
+    PolicyDocument: JSON
+    RouteTableIds: [ String ]
+    ServiceName: String
+    VpcId: String
   "AWS::EC2::NetworkAcl" :
    Properties:
     VpcId: String


### PR DESCRIPTION
An AWS::EC2::VPCEndpoint resource allows for an AWS service endpoint to
be created and configured within a VPC which allows direct access to
that AWS service without having to access the public endpoint outside of
the VPC. This is useful when setting up private subnets on a VPC which
have limited access to publicly routable internet traffic.

Let me know if I've done this incorrectly and/or need to add additional samples/tests.

Thanks to all for your work on cfndsl, it's been quite helpful for our team so far. Cheers!