### PR TITLE
Ensure output file gets closed in rake generate task

### DIFF
--- a/lib/cfndsl/rake_task.rb
+++ b/lib/cfndsl/rake_task.rb
@@ -21,7 +21,9 @@ module CfnDsl
 
     def generate(opts)
       log(opts)
-      outputter(opts).puts model(opts[:filename])
+      outputter(opts) do |output|
+        output.puts model(opts[:filename])
+      end
     end
 
     def log(opts)
@@ -30,7 +32,7 @@ module CfnDsl
     end
 
     def outputter(opts)
-      opts[:output].nil? ? STDOUT : file_output(opts[:output])
+      opts[:output].nil? ? yield(STDOUT) : file_output(opts[:output]) { |f| yield f }
     end
 
     def model(filename)
@@ -48,7 +50,7 @@ module CfnDsl
     end
 
     def file_output(path)
-      File.open(File.expand_path(path), "w")
+      File.open(File.expand_path(path), "w") { |f| yield f }
     end
   end
 end


### PR DESCRIPTION
This pull request ensures that the output file in the rake task gets properly closed. This is important if you wish to use the output in a subsequent rake task, for example creating the stack in CloudFormation. If the file doesn't get closed properly there is a race condition between the file being flushed and it being read, which often results in an empty file being read.