### PR TITLE
pretty json

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Usage: cfndsl [options] FILE
     -y, --yaml FILE                  Import yaml file as local variables
     -r, --ruby FILE                  Evaluate ruby file before template
     -j, --json FILE                  Import json file as local variables
+    -p, --pretty                     Pretty-format output JSON
     -D, --define "VARIABLE=VALUE"    Directly set local VARIABLE as VALUE
     -v, --verbose                    Turn on verbose ouptut
     -h, --help                       Display this screen

--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -2,6 +2,7 @@
 
 require 'cfndsl'
 require 'optparse'
+require 'json'
 
 options = {}
 
@@ -27,6 +28,9 @@ optparse = OptionParser.new do|opts|
     options[:extras].push([:json,File.expand_path(file)])
   end
 
+  opts.on( '-p', '--pretty', 'Pretty-format output JSON') do
+    options[:pretty] = true
+  end
 
   opts.on( '-D', '--define "VARIABLE=VALUE"', 'Directly set local VARIABLE as VALUE' ) do |file|
     options[:extras].push([:raw,file])
@@ -64,4 +68,4 @@ else
   verbose.puts("Writing to STDOUT") if verbose
 end
 
-output.puts model.to_json
+output.puts options[:pretty] ? JSON.pretty_generate(model) : model.to_json


### PR DESCRIPTION
Add the `--pretty` option to output formatted JSON.

This may be important to those who source-control their generated CloudFormation and wish to diff it.