### PR TITLE
Include proof of concept

### DIFF
--- a/lib/cfndsl/JSONable.rb
+++ b/lib/cfndsl/JSONable.rb
@@ -176,6 +176,14 @@ module CfnDsl
       self.instance_eval &block if block_given?
     end
 
+    def include(filename)
+      # TODO: Assume relative for now, should we have a path?
+      caller_file = Pathname.new(caller(1)[0].split(':')[0])
+      filename = caller_file.dirname + Pathname.new("_#{filename}.rb")
+      contents = filename.read
+      self.instance_eval contents, filename.to_s
+    end
+
     def method_missing(meth, *args, &block)
       error = "Undefined symbol: #{meth}"
       error = "#{error}(" + args.inspect[1..-2] + ")" unless args.empty?

--- a/spec/cfndsl_stack_spec.rb
+++ b/spec/cfndsl_stack_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'Stacked' do
+  let(:template) { File.expand_path('../fixtures/stacked.rb', __FILE__) }
+  let(:subject) { CfnDsl.eval_file_with_extras(template).to_json }
+
+  it 'renders a valid json' do
+    expect(subject).to eq('{"AWSTemplateFormatVersion":"2010-09-09","Description":"Test","Parameters":{"One":{"Type":"String"}}}')
+  end
+end

--- a/spec/fixtures/_parameters.rb
+++ b/spec/fixtures/_parameters.rb
@@ -1,0 +1,3 @@
+Parameter("One") {
+  String
+}

--- a/spec/fixtures/stacked.rb
+++ b/spec/fixtures/stacked.rb
@@ -1,0 +1,4 @@
+CloudFormation {
+  Description "Test"
+  include 'parameters'
+}


### PR DESCRIPTION
I wanted the ability to split my stacks up into multiple files for readability purposes.

Here is a somewhat naive proof of concept of one possible approach which I would love to get feedback on.

The way it works is you have a master file ```env_stack.rb```
``` ruby
CloudFormation {
  Description "Test"
  include 'parameters_one'
  include 'parameters_two'
}
```

you can then create ```_parameters_one.rb``` and ```_parameters_two.rb```
``` ruby
Parameter("One") {
  String
}
```

``` ruby
Parameter("Two") {
  String
}
```

This will generate the same output as
``` ruby
CloudFormation {
  Description "Test"
  Parameter("One") {
    String
  }
  Parameter("Two") {
    String
  }
}
```