### PR TITLE
Use as_json instead of to_json

### DIFF
--- a/lib/cfndsl/conditions.rb
+++ b/lib/cfndsl/conditions.rb
@@ -6,12 +6,10 @@ module CfnDsl
   # Usage:
   #     Condition :ConditionName, FnEqual(Ref(:ParameterName), 'helloworld')
   class ConditionDefinition < JSONable
+    include JSONSerialisableObject
+
     def initialize(value)
       @value = value
-    end
-
-    def to_json(*a)
-      @value.to_json(*a)
     end
   end
 end

--- a/lib/cfndsl/creation_policy.rb
+++ b/lib/cfndsl/creation_policy.rb
@@ -8,14 +8,12 @@ module CfnDsl
   #     CreationPolicy('ResourceSignal', { 'Count' => 1,  'Timeout' => 'PT10M' })
   #   }
   class CreationPolicyDefinition < JSONable
+    include JSONSerialisableObject
+
     attr_reader :value
 
     def initialize(value)
       @value = value
-    end
-
-    def to_json(*a)
-      @value.to_json(*a)
     end
   end
 end

--- a/lib/cfndsl/json_serialisable_object.rb
+++ b/lib/cfndsl/json_serialisable_object.rb
@@ -1,0 +1,12 @@
+module CfnDsl
+  # JSONSerialisableObject
+  module JSONSerialisableObject
+    def as_json(_options = {})
+      @value
+    end
+
+    def to_json(*a)
+      as_json.to_json(*a)
+    end
+  end
+end

--- a/lib/cfndsl/jsonable.rb
+++ b/lib/cfndsl/jsonable.rb
@@ -1,5 +1,6 @@
 require 'cfndsl/errors'
 require 'cfndsl/ref_check'
+require 'cfndsl/json_serialisable_object'
 
 module CfnDsl
   # These functions are available anywhere inside
@@ -134,7 +135,7 @@ module CfnDsl
     # variables that begin with a single underscore are elided.
     # Instance variables that begin with two underscores have one of
     # them removed.
-    def to_json(*a)
+    def as_json(_options = {})
       hash = {}
       instance_variables.each do |var|
         name = var[1..-1]
@@ -149,7 +150,11 @@ module CfnDsl
 
         hash[name] = instance_variable_get(var) if name
       end
-      hash.to_json(*a)
+      hash
+    end
+
+    def to_json(*a)
+      as_json.to_json(*a)
     end
 
     def ref_children
@@ -186,10 +191,14 @@ module CfnDsl
       @_refs = refs
     end
 
-    def to_json(*a)
+    def as_json(_options = {})
       hash = {}
       hash["Fn::#{@function}"] = @argument
-      hash.to_json(*a)
+      hash
+    end
+
+    def to_json(*a)
+      as_json.to_json(*a)
     end
 
     def references

--- a/lib/cfndsl/mappings.rb
+++ b/lib/cfndsl/mappings.rb
@@ -12,12 +12,10 @@ module CfnDsl
   #               "ap-northeast-1" => { "32" => "ami-9c03a89d", "64" => "ami-a003a8a1" }
   #    })
   class MappingDefinition < JSONable
+    include JSONSerialisableObject
+
     def initialize(value)
       @value = value
-    end
-
-    def to_json(*a)
-      @value.to_json(*a)
     end
   end
 end

--- a/lib/cfndsl/metadata.rb
+++ b/lib/cfndsl/metadata.rb
@@ -3,14 +3,12 @@ require 'cfndsl/jsonable'
 module CfnDsl
   # Handles Metadata objects
   class MetadataDefinition < JSONable
+    include JSONSerialisableObject
+
     attr_reader :value
 
     def initialize(value)
       @value = value
-    end
-
-    def to_json(*a)
-      @value.to_json(*a)
     end
   end
 end

--- a/lib/cfndsl/properties.rb
+++ b/lib/cfndsl/properties.rb
@@ -9,13 +9,12 @@ module CfnDsl
   #   }
   #
   class PropertyDefinition < JSONable
+    include JSONSerialisableObject
+
     attr_reader :value
+
     def initialize(value)
       @value = value
-    end
-
-    def to_json(*a)
-      @value.to_json(*a)
     end
   end
 end

--- a/lib/cfndsl/update_policy.rb
+++ b/lib/cfndsl/update_policy.rb
@@ -13,13 +13,12 @@ module CfnDsl
   #   }
   #
   class UpdatePolicyDefinition < JSONable
+    include JSONSerialisableObject
+
     attr_reader :value
+
     def initialize(value)
       @value = value
-    end
-
-    def to_json(*a)
-      @value.to_json(*a)
     end
   end
 end


### PR DESCRIPTION
If you use require cfndsl in a project that is also using activesupport
then our to_json is overwritten and the objects prefixed with underscore
start appearing.

Fix as per
http://stackoverflow.com/questions/6879589/using-custom-to-json-method-in-nested-objects