### PR TITLE
SQS Queue Creation - missing properties

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -795,6 +795,7 @@ Resources:
       MaximumMessageSize: Integer
       MessageRetentionPeriod: Integer
       ReceiveMessageWaitTimeSeconds: Integer
+      RedrivePolicy: RedrivePolicy
     Attributes:
      Arn: String
      QueueName: String
@@ -1184,3 +1185,6 @@ Types:
    ZoneAwarenessEnabled: Boolean
  SnapshotOptions:
    AutomatedSnapshotStartHour: Integer
+ RedrivePolicy:
+   DeadLetterTargetArn: String
+   MaxReceiveCount: Integer

--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -789,8 +789,12 @@ Resources:
     Queues: [ String ]
   "AWS::SQS::Queue" :
     Properties:
-     VisibilityTimeout: String
-     QueueName: String
+      VisibilityTimeout: String
+      QueueName: String
+      DelaySeconds: Integer
+      MaximumMessageSize: Integer
+      MessageRetentionPeriod: Integer
+      ReceiveMessageWaitTimeSeconds: Integer
     Attributes:
      Arn: String
      QueueName: String


### PR DESCRIPTION
I've added the queue properties that are available through cloudformation - http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html