### PR TITLE
CLI Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 *~
 Gemfile.lock
+tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem 'json'
 
 group :test do
+  gem 'aruba'
   gem 'rake'
   gem 'rspec'
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+describe 'cfndsl', type: :aruba do
+  let(:usage) do
+    <<-USAGE.gsub(/^ {6}/, '').chomp
+      Usage: cfndsl [options] FILE
+          -o, --output FILE                Write output to file
+          -y, --yaml FILE                  Import yaml file as local variables
+          -r, --ruby FILE                  Evaluate ruby file before template
+          -j, --json FILE                  Import json file as local variables
+          -p, --pretty                     Pretty-format output JSON
+          -D, --define "VARIABLE=VALUE"    Directly set local VARIABLE as VALUE
+          -v, --verbose                    Turn on verbose ouptut
+          -h, --help                       Display this screen
+    USAGE
+  end
+
+  let(:template_content) do
+    <<-TEMPLATE.gsub(/^ {6}/, '')
+      CloudFormation do
+        DESC = 'default' unless defined? DESC
+        Description DESC
+      end
+    TEMPLATE
+  end
+
+  before(:each) { write_file('template.rb', template_content) }
+
+  context 'cfndsl' do
+    it 'displays the usage' do
+      run 'cfndsl'
+      expect(last_command_started).to have_output(usage)
+      expect(last_command_started).to have_exit_status(1)
+    end
+  end
+
+  context 'cfndsl --help' do
+    it 'displays the usage' do
+      run_simple 'cfndsl --help'
+      expect(last_command_started).to have_output(usage)
+    end
+  end
+
+  context 'cfndsl FILE' do
+    it 'generates a JSON CloudFormation template' do
+      run_simple 'cfndsl template.rb'
+      expect(last_command_started).to have_output('{"AWSTemplateFormatVersion":"2010-09-09","Description":"default"}')
+    end
+  end
+
+  context 'cfndsl FILE --pretty' do
+    it 'generates a pretty JSON CloudFormation template' do
+      run_simple 'cfndsl template.rb --pretty'
+      expect(last_command_started).to have_output(<<-OUTPUT.gsub(/^ {8}/, '').chomp)
+        {
+          "AWSTemplateFormatVersion": "2010-09-09",
+          "Description": "default"
+        }
+      OUTPUT
+    end
+  end
+
+  context 'cfndsl FILE --output FILE' do
+    it 'writes the JSON CloudFormation template to a file' do
+      run_simple 'cfndsl template.rb --output template.json'
+      expect(read('template.json')).to eq(['{"AWSTemplateFormatVersion":"2010-09-09","Description":"default"}'])
+    end
+  end
+
+  context 'cfndsl FILE --yaml FILE' do
+    before { write_file('params.yaml', 'DESC: yaml') }
+
+    it 'interpolates the YAML file in the CloudFormation template' do
+      run_simple 'cfndsl template.rb --yaml params.yaml'
+      expect(last_command_started).to have_output('{"AWSTemplateFormatVersion":"2010-09-09","Description":"yaml"}')
+    end
+  end
+
+  context 'cfndsl FILE --json FILE' do
+    before { write_file('params.json', '{"DESC":"json"}') }
+
+    it 'interpolates the JSON file in the CloudFormation template' do
+      run_simple 'cfndsl template.rb --json params.json'
+      expect(last_command_started).to have_output('{"AWSTemplateFormatVersion":"2010-09-09","Description":"json"}')
+    end
+  end
+
+  context 'cfndsl FILE --ruby FILE' do
+    before { write_file('params.rb', 'DESC = "ruby"') }
+
+    it 'interpolates the JSON file in the CloudFormation template' do
+      run_simple 'cfndsl template.rb --ruby params.rb'
+      expect(last_command_started).to have_output('{"AWSTemplateFormatVersion":"2010-09-09","Description":"ruby"}')
+    end
+  end
+
+  context 'cfndsl FILE --define VARIABLE=VALUE' do
+    it 'interpolates the command line variables in the CloudFormation template' do
+      run_simple "cfndsl template.rb --define \"DESC='cli'\""
+      expect(last_command_started).to have_output('{"AWSTemplateFormatVersion":"2010-09-09","Description":"cli"}')
+    end
+  end
+
+  context 'cfndsl FILE --verbose' do
+    before { write_file('params.yaml', 'DESC: yaml') }
+
+    it 'displays the variables as they are interpolated in the CloudFormation template' do
+      run_simple 'cfndsl template.rb --yaml params.yaml --verbose'
+      verbose = /
+        Loading \s YAML \s file \s .* params\.yaml \n
+        Setting \s local \s variable \s DESC \s to \s yaml \n
+        Loading \s template \s file \s .* template.rb \n
+        Writing \s to \s STDOUT
+      /x
+      template = '{"AWSTemplateFormatVersion":"2010-09-09","Description":"yaml"}'
+      expect(last_command_started).to have_output_on_stderr(verbose)
+      expect(last_command_started).to have_output_on_stdout(template)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require 'cfndsl'
+require 'aruba/rspec'
+
+bindir = File.expand_path('../../bin', __FILE__)
+ENV['PATH'] = [ENV['PATH'], bindir].join(':')


### PR DESCRIPTION
Tests should cover the behavior of the cli as well.

Takeaways:
* The app exits 1 when `cfndsl` is invoked with no arguments. To me, that should be functionally equivalent to `cfndsl --help`. This could be fixed easily in `bin/nimbus`.
* Having separate flags for `--json`, `--yaml` and `--ruby` seems unnecessary. They could be combined into one that infers the content based upon the conventional file extension `.yaml`, `.json`, `.rb`.
* The `-D` option seems quite cumbersome and scary at the same time. Allowing a user to execute arbitrary ruby is worrisome at best, and the need to have it be properly parsed makes it difficult to invoke. I believe overriding a single config entry like this is powerful, but I think this approach could use some more thought. I will be making a follow-up issue/pull request detailing a new approach to configuration.