### PR TITLE
Fix Rake task for bumping version number

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ task :bump, :type do |_, args|
   puts "Bumping gem from version #{CfnDsl::VERSION} to #{version} as a '#{type.capitalize}' release"
 
   contents         = File.read version_path
-  updated_contents = contents.gsub(/([0-9\.]+)/, version)
+  updated_contents = contents.gsub(/'[0-9\.]+'/, "'#{version}'")
   File.write(version_path, updated_contents)
 
   puts 'Commiting version update'


### PR DESCRIPTION
### Problem

After the rubocop changes `.freeze` was introduced into the version number and this caused the regex to capture and replace a little too much of the version number resulting in [this](https://github.com/stevenjack/cfndsl/commit/08c1872ddecf3ec01f4fe194811960599d98d40e).

### Solution

Capture everything in the single quotes and replace that with the new version number.