### PR TITLE
Remove erroneous logstream output and use post_install to inform users

### DIFF
--- a/cfndsl.gemspec
+++ b/cfndsl.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.executables << 'cfndsl'
 
   s.add_development_dependency 'bundler'
+
+  s.post_install_message = "'addTag' is now deprecated in favour of 'add_tag'. 'addTag' will be removed in the next major version."
 end

--- a/lib/cfndsl/resources.rb
+++ b/lib/cfndsl/resources.rb
@@ -12,7 +12,6 @@ module CfnDsl
     # rubocop:disable UnusedMethodArgument
     # rubocop:disable UselessAssignment
     def addTag(name, value, propagate = nil)
-      logstream.puts("This method is deprecated and will be removed in the next major release, please use 'add_tag' instead.") if logstream
       add_tag(name, value, propagate = nil)
     end
 


### PR DESCRIPTION
### Problem

`logstream.puts("This method is deprecated and will be removed in the next major release, please use 'add_tag' instead.") if logstream` was incorrectly added assuming that a `logstream` object existed in the context of the `Resources` object. This wasn't the case and ended up blowing up for some users who in the context of running this had a variable defined as `logstream` that may or may not have a `puts` method on it.

### Solution

Remove this as it's incorrect and move the deprecation warning into the `post_install`. Downside of this is  that it's not as direct as having the output in the deprecated method call but having any other method of output in the message may end up breaking the expected output people have espcially is their parsing the end result of what cfndsl generates.