### PR TITLE
Exparams hierarchy

### DIFF
--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -85,7 +85,7 @@ module CfnDsl
       end
     end
 
-    CfnDsl::CloudFormationTemplate.external_parameters params
+    CfnDsl::JSONable.external_parameters params
     logstream.puts("Loading template file #{filename}") if logstream
     b.eval(File.read(filename), filename)
   end

--- a/lib/cfndsl/jsonable.rb
+++ b/lib/cfndsl/jsonable.rb
@@ -130,6 +130,15 @@ module CfnDsl
     extend Functions
     include RefCheck
 
+    def self.external_parameters(params = nil)
+      @@external_parameters ||= {}
+      @@external_parameters = params if params
+      @@external_parameters
+    end
+
+    def external_parameters
+      self.class.external_parameters
+    end    
     # Use instance variables to build a json object. Instance
     # variables that begin with a single underscore are elided.
     # Instance variables that begin with two underscores have one of

--- a/lib/cfndsl/jsonable.rb
+++ b/lib/cfndsl/jsonable.rb
@@ -138,7 +138,7 @@ module CfnDsl
 
     def external_parameters
       self.class.external_parameters
-    end    
+    end
     # Use instance variables to build a json object. Instance
     # variables that begin with a single underscore are elided.
     # Instance variables that begin with two underscores have one of

--- a/lib/cfndsl/orchestration_template.rb
+++ b/lib/cfndsl/orchestration_template.rb
@@ -10,15 +10,6 @@ module CfnDsl
     dsl_attr_setter :AWSTemplateFormatVersion, :Description
     dsl_content_object :Condition, :Parameter, :Output, :Resource, :Mapping
 
-    def self.external_parameters(params = nil)
-      @external_parameters = params if params
-      @external_parameters
-    end
-
-    def external_parameters
-      self.class.external_parameters
-    end
-
     def initialize
       @AWSTemplateFormatVersion = '2010-09-09'
     end

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe CfnDsl do
   it 'evaluates a cloud formation' do
     filename = "#{File.dirname(__FILE__)}/fixtures/test.rb"
-    subject.eval_file_with_extras(filename)
+    subject.eval_file_with_extras(filename, [[:raw, 'test=123']])
   end
 
   it 'evaluates a heat' do

--- a/spec/fixtures/test.rb
+++ b/spec/fixtures/test.rb
@@ -2,7 +2,7 @@ CloudFormation do
   TEST ||= 'no value set'.freeze
   puts TEST
 
-  Description 'Test'
+  Description external_parameters[:test]
 
   Parameter('One') do
     String
@@ -47,7 +47,7 @@ CloudFormation do
       DeviceName '/dev/sda'
       VirtualName 'stuff'
       Ebs do
-        SnapshotId 'asdasdfasdf'
+        SnapshotId external_parameters[:test]
         VolumeSize Ref('MyInstance')
       end
     end


### PR DESCRIPTION
`external_parameters` was only available to the top level CloudFormation scope. Adding it to JSONable and using class hierarchy variables allows it to be accessed from within any block of the template.

Additionally, I added a few lines to `cfndsl_spec.rb` to ensure the params were being interpreted correctly.

Currently, this fails `RuboCop` because of the use of `@@` class hierarchy variables. They can be replaced with the `class_attribute` pattern from `activesupport`. It's quite a lot of code to replicate the behavior, however.