### PR TITLE
Add in Route53 Health Check Tags as a type

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -482,6 +482,15 @@ Resources:
     ElasticsearchClusterConfig: ElasticsearchClusterConfig
     SnapshotOptions: SnapshotOptions
     Tags: [ EC2Tag ]
+  "AWS::Events::Rule" :
+    Properties:
+      Description: String
+      EventPattern: JSON
+      Name: String
+      RoleArn: String
+      SchduleExpression: String
+      State: String
+      Targets: [ EventsRuleTarget ]
   "AWS::IAM::AccessKey" :
    Properties:
     Serial: Integer
@@ -1216,3 +1225,8 @@ Types:
  VpcConfig:
    SecurityGroupIds: [ String ]
    SubnetIds: [ String ]
+ EventsRuleTarget:
+   Arn: String
+   Id: String
+   Input: String
+   InputPath: String

--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -751,6 +751,7 @@ Resources:
   "AWS::Route53::HealthCheck" :
    Properties:
     HealthCheckConfig: Route53HealthCheckConfig
+    HealthCheckTags: [ Route53HealthCheckTags ]
   "AWS::Route53::RecordSet" :
    Properties:
     HostedZoneId: String
@@ -1085,6 +1086,9 @@ Types:
    ResourcePath: String
    SearchString: String
    Type: String
+ Route53HealthCheckTags:
+   Key: String
+   Value: String
  VpcSettings:
    SubnetIds: [ String ]
    VpcId: String


### PR DESCRIPTION
This adds the type "HealthCheckTags" so that you can add tags to your Route 53 Health Checks.