### PR TITLE
Osduplicatekey

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -482,6 +482,15 @@ Resources:
     ElasticsearchClusterConfig: ElasticsearchClusterConfig
     SnapshotOptions: SnapshotOptions
     Tags: [ EC2Tag ]
+  "AWS::Events::Rule" :
+    Properties:
+      Description: String
+      EventPattern: JSON
+      Name: String
+      RoleArn: String
+      SchduleExpression: String
+      State: String
+      Targets: [ EventsRuleTarget ]
   "AWS::IAM::AccessKey" :
    Properties:
     Serial: Integer
@@ -1216,3 +1225,8 @@ Types:
  VpcConfig:
    SecurityGroupIds: [ String ]
    SubnetIds: [ String ]
+ EventsRuleTarget:
+   Arn: String
+   Id: String
+   Input: String
+   InputPath: String

--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -751,6 +751,7 @@ Resources:
   "AWS::Route53::HealthCheck" :
    Properties:
     HealthCheckConfig: Route53HealthCheckConfig
+    HealthCheckTags: [ Route53HealthCheckTags ]
   "AWS::Route53::RecordSet" :
    Properties:
     HostedZoneId: String
@@ -1085,6 +1086,9 @@ Types:
    ResourcePath: String
    SearchString: String
    Type: String
+ Route53HealthCheckTags:
+   Key: String
+   Value: String
  VpcSettings:
    SubnetIds: [ String ]
    VpcId: String

--- a/lib/cfndsl/os/types.yaml
+++ b/lib/cfndsl/os/types.yaml
@@ -1964,10 +1964,6 @@ Types:
     # Updates cause replacement.
     # Optional property, defaults to “1”.
     # The value must be in the range 1 to 512.
-    sequence : String
-    # A character sequence and its corresponding min constraint to generate the random string from.
-    # Updates cause replacement.
-    # Required property.
     length : Integer
     # Length of the string to generate.
     # Updates cause replacement.


### PR DESCRIPTION
This removes a duplicate key in the OS types.  #191 requires this to pass tests.