### PR TITLE
Update types.yaml - fixed tenancey typo

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -212,7 +212,7 @@ Resources:
     SourceDestCheck: Boolean
     SubnetId: String
     Tags: [ EC2Tag ]
-    Tenancey: String
+    Tenancy: String
     UserData: String
     Volumes: [ EC2MountPoint ]
    Attributes:


### PR DESCRIPTION
Simple typo fix in "AWS::EC2::Instance" tenancy property.