### PR TITLE
Rubocop 0.40 Fixes

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -482,6 +482,15 @@ Resources:
     ElasticsearchClusterConfig: ElasticsearchClusterConfig
     SnapshotOptions: SnapshotOptions
     Tags: [ EC2Tag ]
+  "AWS::Events::Rule" :
+    Properties:
+      Description: String
+      EventPattern: JSON
+      Name: String
+      RoleArn: String
+      SchduleExpression: String
+      State: String
+      Targets: [ EventsRuleTarget ]
   "AWS::IAM::AccessKey" :
    Properties:
     Serial: Integer
@@ -1216,3 +1225,8 @@ Types:
  VpcConfig:
    SecurityGroupIds: [ String ]
    SubnetIds: [ String ]
+ EventsRuleTarget:
+   Arn: String
+   Id: String
+   Input: String
+   InputPath: String

--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -751,6 +751,7 @@ Resources:
   "AWS::Route53::HealthCheck" :
    Properties:
     HealthCheckConfig: Route53HealthCheckConfig
+    HealthCheckTags: [ Route53HealthCheckTags ]
   "AWS::Route53::RecordSet" :
    Properties:
     HostedZoneId: String
@@ -1085,6 +1086,9 @@ Types:
    ResourcePath: String
    SearchString: String
    Type: String
+ Route53HealthCheckTags:
+   Key: String
+   Value: String
  VpcSettings:
    SubnetIds: [ String ]
    VpcId: String

--- a/sample/autoscale.rb
+++ b/sample/autoscale.rb
@@ -51,8 +51,7 @@ a stack from this template.
           'us-west-1' => { '32' => 'ami-c9c7978c', '64' => 'ami-cfc7978a' },
           'eu-west-1' => { '32' => 'ami-37c2f643', '64' => 'ami-31c2f645' },
           'ap-southeast-1' => { '32' => 'ami-66f28c34', '64' => 'ami-60f28c32' },
-          'ap-northeast-1' => { '32' => 'ami-9c03a89d', '64' => 'ami-a003a8a1' }
-         )
+          'ap-northeast-1' => { '32' => 'ami-9c03a89d', '64' => 'ami-a003a8a1' })
 
   # We can also write arbitrary ruby code
 
@@ -185,7 +184,8 @@ a stack from this template.
                  {
                    'Name' => 'AutoScalingGroupName',
                    'Value' => Ref('WebServerGroup')
-                 }])
+                 }
+               ])
     end
   end
 
@@ -198,7 +198,8 @@ a stack from this template.
                  'LoadBalancerPort' => '80',
                  'InstancePort' => Ref('WebServerPort'),
                  'Protocol' => 'HTTP'
-               }])
+               }
+             ])
     Property('HealthCheck',
              # FnFormat replaces %0, %1, etc with passed in parameters
              # Note that it renders to a call to Fn::Join in the json.
@@ -206,8 +207,7 @@ a stack from this template.
              'HealthyThreshold' => '3',
              'UnhealthyThreshold' => '5',
              'Interval' => '30',
-             'Timeout' => '5'
-            )
+             'Timeout' => '5')
   end
 
   Resource('InstanceSecurityGroup') do
@@ -227,7 +227,8 @@ a stack from this template.
                  'ToPort' => Ref('WebServerPort'),
                  'SourceSecurityGroupOwnerId' => FnGetAtt('ElasticLoadBalancer', 'SourceSecurityGroup.OwnerAlias'),
                  'SourceSecurityGroupName' => FnGetAtt('ElasticLoadBalancer', 'SourceSecurityGroup.GroupName')
-               }])
+               }
+             ])
   end
 
   Output('URL') do

--- a/sample/autoscale2.rb
+++ b/sample/autoscale2.rb
@@ -50,8 +50,7 @@ a stack from this template.
           'us-west-1' => { '32' => 'ami-c9c7978c', '64' => 'ami-cfc7978a' },
           'eu-west-1' => { '32' => 'ami-37c2f643', '64' => 'ami-31c2f645' },
           'ap-southeast-1' => { '32' => 'ami-66f28c34', '64' => 'ami-60f28c32' },
-          'ap-northeast-1' => { '32' => 'ami-9c03a89d', '64' => 'ami-a003a8a1' }
-         )
+          'ap-northeast-1' => { '32' => 'ami-9c03a89d', '64' => 'ami-a003a8a1' })
 
   # We can also write arbitrary ruby code
 
@@ -91,8 +90,7 @@ a stack from this template.
     UpdatePolicy('AutoScalingRollingUpdate',
                  'MinInstancesInService' => '1',
                  'MaxBatchSize'          => '1',
-                 'PauseTime'             => 'PT15M'
-                )
+                 'PauseTime'             => 'PT15M')
     AvailabilityZones FnGetAZs('')
     LaunchConfigurationName Ref('LaunchConfig')
     MinSize 1
@@ -188,7 +186,8 @@ a stack from this template.
                  'LoadBalancerPort' => '80',
                  'InstancePort' => Ref('WebServerPort'),
                  'Protocol' => 'HTTP'
-               }])
+               }
+             ])
     Property('HealthCheck',
              # FnFormat replaces %0, %1, etc with passed in parameters
              # Note that it renders to a call to Fn::Join in the json.
@@ -196,8 +195,7 @@ a stack from this template.
              'HealthyThreshold' => '3',
              'UnhealthyThreshold' => '5',
              'Interval' => '30',
-             'Timeout' => '5'
-            )
+             'Timeout' => '5')
   end
 
   Resource('InstanceSecurityGroup') do
@@ -217,7 +215,8 @@ a stack from this template.
                  'ToPort' => Ref('WebServerPort'),
                  'SourceSecurityGroupOwnerId' => FnGetAtt('ElasticLoadBalancer', 'SourceSecurityGroup.OwnerAlias'),
                  'SourceSecurityGroupName' => FnGetAtt('ElasticLoadBalancer', 'SourceSecurityGroup.GroupName')
-               }])
+               }
+             ])
   end
 
   Output('URL') do

--- a/sample/codedeploy.rb
+++ b/sample/codedeploy.rb
@@ -16,8 +16,7 @@ CloudFormation do
     Type 'AWS::CodeDeploy::DeploymentConfig'
     Property('MinimumHealthyHosts',
              Type: 'FLEET_PERCENT',
-             Value: '50'
-            )
+             Value: '50')
   end
 
   Resource('MyDeploymentGroup') do
@@ -35,8 +34,7 @@ CloudFormation do
                  ETag: '1234567890ABCDEF',
                  Version: '10'
                }
-             }
-            )
+             })
     Property('Ec2TagFilters', [{
                Key: 'Role',
                Value: 'myapp',

--- a/sample/config_service.rb
+++ b/sample/config_service.rb
@@ -54,7 +54,8 @@ CloudFormation do
     ManagedPolicyArns(
       [
         'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
-      ])
+      ]
+    )
   end
 
   Topic('ConfigServiceTopic') do

--- a/sample/lambda.rb
+++ b/sample/lambda.rb
@@ -11,8 +11,7 @@ CloudFormation do
     Property('Role', Ref('Role'))
     Property('Code',
              S3Bucket: 'lambda-functions',
-             S3Key: 'amilookup.zip'
-            )
+             S3Key: 'amilookup.zip')
     Property('Runtime', 'nodejs')
     Property('Timeout', '25')
   end

--- a/spec/fixtures/test.rb
+++ b/spec/fixtures/test.rb
@@ -24,14 +24,16 @@ CloudFormation do
               [
                 FnEquals(Ref('One'), 'Test'),
                 FnNot(FnEquals(Ref('Two'), 'Test'))
-              ]))
+              ]
+            ))
 
   Condition('OneIsTestOrTwoIsTest',
             FnOr(
               [
                 FnEquals(Ref('One'), 'Test'),
                 FnEquals(Ref('Two'), 'Test')
-              ]))
+              ]
+            ))
 
   Output(:One, FnBase64(Ref('One')))
 
@@ -67,8 +69,7 @@ CloudFormation do
     UpdatePolicy('AutoScalingRollingUpdate',
                  'MinInstancesInService' => '1',
                  'MaxBatchSize'          => '1',
-                 'PauseTime'             => 'PT15M'
-                )
+                 'PauseTime'             => 'PT15M')
     AvailabilityZones FnGetAZs('')
     LaunchConfigurationName Ref('LaunchConfig')
     MinSize 1


### PR DESCRIPTION
This fixes violations in new version of rubocop.

This will resolve the CI failures that @johnhyland is seeing in https://github.com/stevenjack/cfndsl/pull/194