### PR TITLE
Add Boolean for UseOpsworksSecurityGroups

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -628,6 +628,7 @@ Resources:
       Name: String
       ServiceRoleArn: String
       UseCustomCookbooks: Boolean
+      UseOpsworksSecurityGroups: Boolean
       VpcId: String
   "AWS::RDS::DBCluster" :
     Properties:


### PR DESCRIPTION
Was importing a bunch of stack configs and noticed this property was missing. We like to be able to explicitly set this to false because it's a pain to clean up if it ever gets turned on by accident.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-stack.html#cfn-opsworks-stack-useopsworkssecuritygroups