### PR TITLE
Remove List context for VpcSettings Datatype

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -150,7 +150,7 @@ Resources:
     Password : String
     ShortName : String
     Size : String
-    VpcSettings: [ VpcSettings ]
+    VpcSettings: VpcSettings
   "AWS::DirectoryService::MicrosoftAD" :
    Properties :
     CreateAlias : Boolean
@@ -158,7 +158,7 @@ Resources:
     Name : String
     Password : String
     ShortName : String
-    VpcSettings: [ VpcSettings ]
+    VpcSettings: VpcSettings
   "AWS::DynamoDB::Table" :
    Properties :
     AttributeDefinitions : [ AttributeDefinitionsType ]


### PR DESCRIPTION
I added this in a previous PR and it's the wrong data type, generates invalid CF.