### PR TITLE
set context to sensible names. Use Resource/Type

### DIFF
--- a/spec/resources_spec.rb
+++ b/spec/resources_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe CfnDsl::ResourceDefinition do
-  subject { CfnDsl::CloudFormationTemplate.new.EC2_Instance(:single_server) }
-  context '#all_refs' do
+  subject { CfnDsl::CloudFormationTemplate.new.Resource(:single_server) }
+  context '#ResourceTypeEC2' do
     it 'checks that the type is AWS::EC2::Instance' do
+      subject.Type('AWS::EC2::Instance')
       expect(subject.instance_variable_get('@Type')).to eq('AWS::EC2::Instance')
     end
   end
@@ -11,7 +12,7 @@ end
 
 describe CfnDsl::ResourceDefinition do
   subject { CfnDsl::CloudFormationTemplate.new.AutoScalingGroup(:web_servers) }
-  context '#all_refs' do
+  context '#ResourceTypeASG' do
     it 'checks that the type is AWS::AutoScaling::AutoScalingGroup' do
       expect(subject.instance_variable_get('@Type')).to eq('AWS::AutoScaling::AutoScalingGroup')
     end


### PR DESCRIPTION
This fixes the context names @stevenjack.

One thing I don't understand, this test doesn't fail if I comment out my previous fix in #207.
It still fails actually running cfndsl, but somethings different in the way rspec is setting it up. Suggestions anyone?