### PR TITLE
Replaced binding.eval

### DIFF
--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -63,13 +63,6 @@ filename = File.expand_path(ARGV[0])
 verbose = options[:verbose] && STDERR
 if options[:disable_binding]
   CfnDsl.disable_binding
-else
-  STDERR.puts <<-MSG
-The creation of constants as config is deprecated!
-Please switch to the #external_parameters method within your templates to access variables
-See https://github.com/stevenjack/cfndsl/issues/170
-Use the --disable-binding flag to suppress this message
-MSG
 end
 
 model = CfnDsl.eval_file_with_extras(filename, options[:extras], verbose)

--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -83,7 +83,13 @@ module CfnDsl
           b.eval(File.read(file), file)
         end
       when :raw
-        params.set_param(*file.split('='))
+        begin
+          key, value = file.match(/^([_a-zA-Z0-9]+)=(.+)$/)[1..2]
+        rescue
+          logstream.puts 'Error: Invalid input. Variable must match the regex ^([_a-zA-Z0-9]+)=(.+)$'
+          exit 1
+        end
+        params.set_param(key, value)
         params.add_to_binding(b, logstream) unless disable_binding?
       end
     end

--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -73,15 +73,18 @@ module CfnDsl
         if disable_binding?
           logstream.puts("Interpreting Ruby files was disabled. #{file} will not be read") if logstream
         else
+          STDERR.puts <<-MSG
+            WARNING: Ruby files are loaded with eval(). This may be a security risk to your organization.
+            WARNING: Creation of constants with ruby is deprecated. Please use a different method.
+            See https://github.com/stevenjack/cfndsl/issues/170
+            Use the --disable-binding flag to suppress this message
+          MSG
           logstream.puts("Running ruby file #{file}") if logstream
           b.eval(File.read(file), file)
         end
       when :raw
         params.set_param(*file.split('='))
-        unless disable_binding?
-          logstream.puts("Running raw ruby code #{file}") if logstream
-          b.eval(file, 'raw code')
-        end
+        params.add_to_binding(b, logstream) unless disable_binding?
       end
     end
 

--- a/lib/cfndsl/external_parameters.rb
+++ b/lib/cfndsl/external_parameters.rb
@@ -43,7 +43,7 @@ module CfnDsl
     def add_to_binding(bind, logstream)
       parameters.each_pair do |key, val|
         logstream.puts("Setting local variable #{key} to #{val}") if logstream
-        bind.eval "#{key} = #{val.inspect}"
+        bind.local_variable_set(key.to_sym, val)
       end
     end
 


### PR DESCRIPTION
In regards to https://github.com/stevenjack/cfndsl/issues/170

Deprecation of the binding feature may not be necessary. Although `eval()` is insecure, it is not the only method that can be used to bring variables into bindings.

This commit replaces `binding.eval` with `binding.instance_variable_set`. This allows for secure loading of config as constants, since no arbitrary code is run. (Except if loading ruby files, of course). Potentially insecure code is passed in as a string.

The deprecation warning has been left in for Ruby files, since those would still be insecure.