### PR TITLE
Add GroupName property to IAM Group resource

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -582,6 +582,7 @@ Resources:
     SecretAccessKey: String
   "AWS::IAM::Group" :
    Properties:
+    GroupName: String
     ManagedPolicyArns: [ String ]
     Path: String
     Policies: [ IAMEmbeddedPolicy ]


### PR DESCRIPTION
GroupName property is missing from IAM Group resource: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html
