### PR TITLE
Feature/add ecs task definition properties

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -1028,6 +1028,7 @@ Resources:
    Properties:
     ContainerDefinitions: [ ECSContainerDefinition ]
     Volumes: [ ECSVolume ]
+    TaskRoleArn: String
   "AWS::CodeDeploy::Application" :
     Properties:
       ApplicationName: String

--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -1029,6 +1029,7 @@ Resources:
     ContainerDefinitions: [ ECSContainerDefinition ]
     Volumes: [ ECSVolume ]
     TaskRoleArn: String
+    Family: String
   "AWS::CodeDeploy::Application" :
     Properties:
       ApplicationName: String

--- a/spec/aws/ecs_task_definition_spec.rb
+++ b/spec/aws/ecs_task_definition_spec.rb
@@ -11,5 +11,13 @@ describe CfnDsl::CloudFormationTemplate do
 
       expect(template.to_json).to include('"TaskRoleArn":"arn:aws:iam::123456789012:role/S3Access"')
     end
+
+    it 'supports Family property' do
+      template.ECS_TaskDefinition(:Test) do
+        Family 'Fam'
+      end
+
+      expect(template.to_json).to include('"Family":"Fam"')
+    end
   end
 end

--- a/spec/aws/ecs_task_definition_spec.rb
+++ b/spec/aws/ecs_task_definition_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CfnDsl::CloudFormationTemplate do
+  subject(:template) { described_class.new }
+
+  describe "#ECS_TaskDefinition" do
+    it 'supports TaskRoleArn property' do
+      template.ECS_TaskDefinition(:Test) do
+        TaskRoleArn 'arn:aws:iam::123456789012:role/S3Access'
+      end
+
+      expect(template.to_json).to include('"TaskRoleArn":"arn:aws:iam::123456789012:role/S3Access"')
+    end
+  end
+end

--- a/spec/aws/ecs_task_definition_spec.rb
+++ b/spec/aws/ecs_task_definition_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe CfnDsl::CloudFormationTemplate do
   subject(:template) { described_class.new }
 
-  describe "#ECS_TaskDefinition" do
+  describe '#ECS_TaskDefinition' do
     it 'supports TaskRoleArn property' do
       template.ECS_TaskDefinition(:Test) do
         TaskRoleArn 'arn:aws:iam::123456789012:role/S3Access'


### PR DESCRIPTION
Hi,

Really useful gem!

I noticed the ECS::TaskDefinition was missing properties for [Family](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-family) and [TaskRoleArn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-taskrolearn).

I also added some unit tests but not sure if it is useful.