### PR TITLE
Add support for LogGroupName Property

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -696,6 +696,7 @@ Resources:
       KeyPolicy: JSON
   "AWS::Logs::LogGroup" :
     Properties:
+      LogGroupName: String
       RetentionInDays: Integer
   "AWS::Logs::MetricFilter" :
     Properties:

--- a/spec/aws/logs_log_group_spec.rb
+++ b/spec/aws/logs_log_group_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe CfnDsl::CloudFormationTemplate do
+  subject(:template) { described_class.new }
+
+  describe "#Logs_LogGroup" do
+    it 'supports RetentionInDays' do
+      template.Logs_LogGroup(:Test) do
+        RetentionInDays 7
+      end
+
+      expect(template.to_json).to include('"RetentionInDays":7')
+    end
+
+    it 'supports LogGroupName' do
+      template.Logs_LogGroup(:Test) do
+        LogGroupName 'TestLogGroup'
+      end
+
+      expect(template.to_json).to include('"LogGroupName":"TestLogGroup')
+    end
+  end
+end

--- a/spec/aws/logs_log_group_spec.rb
+++ b/spec/aws/logs_log_group_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe CfnDsl::CloudFormationTemplate do
   subject(:template) { described_class.new }
 
-  describe "#Logs_LogGroup" do
-    it 'supports RetentionInDays' do
+  describe '#Logs_LogGroup' do
+    it 'supports RetentionInDays property' do
       template.Logs_LogGroup(:Test) do
         RetentionInDays 7
       end
@@ -12,7 +12,7 @@ describe CfnDsl::CloudFormationTemplate do
       expect(template.to_json).to include('"RetentionInDays":7')
     end
 
-    it 'supports LogGroupName' do
+    it 'supports LogGroupName property' do
       template.Logs_LogGroup(:Test) do
         LogGroupName 'TestLogGroup'
       end


### PR DESCRIPTION
Adds the [LogGroupName](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html#cfn-cwl-loggroup-loggroupname) property to Logs::LogGroup.