### PR TITLE
No need to enforce this cop: this is a DSL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ Metrics/CyclomaticComplexity:
 Metrics/AbcSize:
   Max: 25
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/MethodLength:
   Max: 25
 


### PR DESCRIPTION
Most of the failures are sample templates, the rest are from the metaprogramming blocks.