### PR TITLE
Add support for AWS::KMS::Alias

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -694,6 +694,10 @@ Resources:
       Enabled: Boolean
       EnableKeyRotation: Boolean
       KeyPolicy: JSON
+  "AWS::KMS::Alias" :
+    Properties:
+      AliasName: String
+      TargetKeyId: String
   "AWS::Logs::LogGroup" :
     Properties:
       LogGroupName: String

--- a/spec/aws/kms_alias_spec.rb
+++ b/spec/aws/kms_alias_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe CfnDsl::CloudFormationTemplate do
+  subject(:template) { described_class.new }
+
+  describe '#KMS_Alias' do
+    it 'supports AliasName property' do
+      template.KMS_Alias(:Test) do
+        AliasName 'test-key'
+      end
+
+      expect(template.to_json).to include('"AliasName":"test-key"')
+    end
+
+    it 'supports TargetKeyId property' do
+      template.KMS_Alias(:Test) do
+        TargetKeyId 'kms-key-123'
+      end
+
+      expect(template.to_json).to include('"TargetKeyId":"kms-key-123"')
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for the [AWS::KMS::Alias](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-alias.html) resource.