### PR TITLE
Add monitoring properties to AWS::RDS::DBInstance

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -813,6 +813,8 @@ Resources:
       LicenseModel: String
       MasterUsername: String
       MasterUserPassword: String
+      MonitoringInterval: Integer
+      MonitoringRoleArn: String
       MultiAZ: Boolean
       OptionGroupName: String
       Port: String

--- a/spec/aws/rds_db_instance_spec.rb
+++ b/spec/aws/rds_db_instance_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe CfnDsl::CloudFormationTemplate do
+  subject(:template) { described_class.new }
+
+  describe '#RDS_DBInstance' do
+    it 'supports MonitoringInterval property' do
+      template.RDS_DBInstance(:Test) do
+        MonitoringInterval 1
+      end
+
+      expect(template.to_json).to include('"MonitoringInterval":1')
+    end
+
+    it 'supports MonitoringRoleArn property' do
+      template.RDS_DBInstance(:Test) do
+        MonitoringRoleArn 'arn:aws:iam:123456789012:role/emaccess'
+      end
+
+      expect(template.to_json).to include('"MonitoringRoleArn":"arn:aws:iam:123456789012:role/emaccess"')
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for [MonitoringInterval](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-monitoringinterval) and [MonitoringRoleArn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-monitoringrolearn) to [AWS::RDS::DBInstance](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html).