### PR TITLE
Added support for Fn::Split intrinsic function.

### DIFF
--- a/lib/cfndsl/generate_types.rb
+++ b/lib/cfndsl/generate_types.rb
@@ -12,7 +12,7 @@ module CfnDsl
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     def generate_types(filename)
-      types = YAML.load(File.open(filename))
+      types = YAML.safe_load(File.open(filename))
       const_set('Types_Internal', types)
 
       validate_types(types)

--- a/lib/cfndsl/jsonable.rb
+++ b/lib/cfndsl/jsonable.rb
@@ -36,6 +36,11 @@ module CfnDsl
       Fn.new('Join', [string, array])
     end
 
+    # Equivalent to the CloudFormation template built in function Fn::Split
+    def FnSplit(string, array)
+      Fn.new('Split', [string, array])
+    end
+
     # Equivalent to the CloudFormation template built in function Fn::And
     def FnAnd(array)
       if !array || array.count < 2 || array.count > 10

--- a/lib/cfndsl/types.rb
+++ b/lib/cfndsl/types.rb
@@ -5,11 +5,12 @@ require 'cfndsl/names'
 require 'cfndsl/types'
 
 module CfnDsl
+  # Types helper
   # rubocop:disable Metrics/ModuleLength
   module Types
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     def self.included(type_def)
-      types_list = YAML.load(File.open("#{File.dirname(__FILE__)}/#{type_def::TYPE_PREFIX}/types.yaml"))
+      types_list = YAML.safe_load(File.open("#{File.dirname(__FILE__)}/#{type_def::TYPE_PREFIX}/types.yaml"))
       type_def.const_set('Types_Internal', types_list)
 
       # Do a little sanity checking - all of the types referenced in Resources

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -132,6 +132,11 @@ describe CfnDsl::CloudFormationTemplate do
       expect(func.to_json).to eq('{"Fn::Join":["A",["B","C"]]}')
     end
 
+    it 'FnSplit' do
+      func = subject.FnSplit('|', 'a|b|c')
+      expect(func.to_json).to eq('{"Fn::Split":["|","a|b|c"]}')
+    end
+
     it 'Ref' do
       ref = subject.Ref 'X'
       expect(ref.to_json).to eq('{"Ref":"X"}')


### PR DESCRIPTION
This intrinsic function  was added on January 17, 2017 (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html).

For more details about its usage see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-split.html.