### PR TITLE
Rubocop best practice change for %w literal delimitation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,22 +14,22 @@ task :cov do
 end
 
 YamlLint::RakeTask.new do |t|
-  t.paths = %w(
+  t.paths = %w[
     lib/cfndsl/aws/types.yaml
     lib/cfndsl/os/types.yaml
     sample/t1.yaml
     .travis.yml
     .rubocop.yml
-  )
+  ]
 end
 
-task default: %i(spec rubocop yamllint)
+task default: %i[spec rubocop yamllint]
 
 task :bump, :type do |_, args|
   type = args[:type].downcase
   version_path = 'lib/cfndsl/version.rb'
 
-  types = %w(major minor patch)
+  types = %w[major minor patch]
 
   raise unless types.include?(type)
 

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -74,7 +74,7 @@ describe CfnDsl::CloudFormationTemplate do
         SecurityGroup 'two'
         groups = @Properties['SecurityGroups'].value
         spec.expect(id).to spec.eq('aaaaa')
-        spec.expect(groups).to spec.eq(%w(one two))
+        spec.expect(groups).to spec.eq(%w[one two])
       end
     end
   end
@@ -128,7 +128,7 @@ describe CfnDsl::CloudFormationTemplate do
     end
 
     it 'FnJoin' do
-      func = subject.FnJoin('A', %w(B C))
+      func = subject.FnJoin('A', %w[B C])
       expect(func.to_json).to eq('{"Fn::Join":["A",["B","C"]]}')
     end
 

--- a/spec/external_parameters_spec.rb
+++ b/spec/external_parameters_spec.rb
@@ -92,7 +92,7 @@ describe CfnDsl::ExternalParameters do
     end
   end
 
-  %i(fetch keys values each_pair).each do |meth|
+  %i[fetch keys values each_pair].each do |meth|
     context "##{meth}" do
       it "delegates the method #{meth} to the underlying parameters" do
         expect(subject.parameters).to receive(meth)

--- a/spec/names_spec.rb
+++ b/spec/names_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 describe CfnDsl do
   context '.method_names' do
     it 'returns an array of string method names when called without a block' do
-      expect(described_class.method_names('foo')).to eq(%w(foo Foo))
+      expect(described_class.method_names('foo')).to eq(%w[foo Foo])
     end
 
     it 'yields symbol method names when called with a block' do
       results = []
       described_class.method_names('foo') { |name| results << name }
-      expect(results).to eq(%i(foo Foo))
+      expect(results).to eq(%i[foo Foo])
     end
   end
 end


### PR DESCRIPTION
Rubocop had a recent change to best practice to use square brackets instead of parentheses when adding literals to %w