### PR TITLE
IAM Managed Policy: Add support for ManagedPolicyName property

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -714,11 +714,12 @@ Resources:
   "AWS::IAM::ManagedPolicy" :
    Properties:
     Description: String
-    PolicyDocument: JSON
-    Path: String
     Groups: [ String ]
-    Users: [ String ]
+    Path: String
+    PolicyDocument: JSON
     Roles: [ String ]
+    Users: [ String ]
+    ManagedPolicyName: String
   "AWS::IAM::Policy" :
    Properties:
     PolicyName: String

--- a/spec/aws/iam_managed_policy_spec.rb
+++ b/spec/aws/iam_managed_policy_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CfnDsl::CloudFormationTemplate do
+  subject(:template) { described_class.new }
+
+  describe '#IAM_ManagedPolicy' do
+    it 'supports ManagedPolicyName property' do
+      template.IAM_ManagedPolicy(:TestPolicy) do
+        ManagedPolicyName 'test-policy'
+      end
+
+      expect(template.to_json).to include('"ManagedPolicyName":"test-policy"')
+    end
+  end
+end


### PR DESCRIPTION
This adds support for the `ManagedPolicyName` property to `IAM_ManagedPolicy`.

As of **5/2/2017**:

```yaml
Type: "AWS::IAM::ManagedPolicy"
Properties: 
  Description: String
  Groups:
    - String
  Path: String
  PolicyDocument: JSON object
  Roles:
    - String
  Users:
    - String
  ManagedPolicyName: String
```

Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html