### PR TITLE
CloudFormation::Stack: Add Tags property

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -213,10 +213,11 @@ Resources:
     ServiceToken: String
   "AWS::CloudFormation::Stack" :
    Properties:
+    NotificationARNs: [ String ]
+    Parameters: CloudFormationStackParameters
+    Tags: [ ResourceTag ]
     TemplateURL: String
     TimeoutInMinutes: String
-    Parameters: CloudFormationStackParameters
-    NotificationARNs: [ String ]
   "AWS::CloudFormation::WaitCondition" :
    Properties:
     Handle: String


### PR DESCRIPTION
Adds support for the `Tags` property to `CloudFormation::Stack`.

As of **5/2/2017**:

```yaml
Type: "AWS::CloudFormation::Stack"
Properties:
  NotificationARNs:
    - String
  Parameters:
    CloudFormation Stack Parameters Property Type
  Tags:
    - Resource Tag
  TemplateURL: String
  TimeoutInMinutes: Integer
```

Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html
