### PR TITLE
EC2::SecurityGroup: Add GroupName property

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -403,11 +403,12 @@ Resources:
     Tags: [ ResourceTag ]
   "AWS::EC2::SecurityGroup" :
     Properties:
+     GroupName: String
      GroupDescription: String
-     SecurityGroupIngress: [ EC2SecurityGroupRule ]
      SecurityGroupEgress: [ EC2SecurityGroupRule ]
-     VpcId: String
+     SecurityGroupIngress: [ EC2SecurityGroupRule ]
      Tags : [ ResourceTag ]
+     VpcId: String
   "AWS::EC2::SecurityGroupEgress" :
    Properties:
     GroupId: String

--- a/spec/aws/ec2_security_group_spec.rb
+++ b/spec/aws/ec2_security_group_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CfnDsl::CloudFormationTemplate do
+  subject(:template) { described_class.new }
+
+  describe '#EC2_SecurityGroup' do
+    it 'supports GroupName property' do
+      template.EC2_SecurityGroup(:Test) do
+        GroupName 'super-group'
+      end
+
+      expect(template.to_json).to include('"GroupName":"super-group"')
+    end
+  end
+end


### PR DESCRIPTION
Updated `EC2::SecurityGroup` to support the `GroupName` property.

Properties supported as of **(5/10/17)**:

```yaml
Type: "AWS::EC2::SecurityGroup"
Properties: 
  GroupName: String
  GroupDescription: String
  SecurityGroupEgress:
    - Security Group Rule
  SecurityGroupIngress:
    - Security Group Rule
  Tags:
    - Resource Tag
  VpcId: String
```

Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html