### PR TITLE
Add generated changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1.0
+- 2.3.3
 sudo: false
 
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,768 @@
+# Change Log
+
+## [v0.12.9](https://github.com/stevenjack/cfndsl/tree/v0.12.9) (2017-05-08)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.8...v0.12.9)
+
+**Merged pull requests:**
+
+- Update AWS::CloudWatch::Alarm with 2 new properties [\#312](https://github.com/stevenjack/cfndsl/pull/312) ([AnominousSign](https://github.com/AnominousSign))
+
+## [v0.12.8](https://github.com/stevenjack/cfndsl/tree/v0.12.8) (2017-05-03)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.7...v0.12.8)
+
+**Merged pull requests:**
+
+- CloudFormation::Stack: Add Tags property [\#311](https://github.com/stevenjack/cfndsl/pull/311) ([mikechau](https://github.com/mikechau))
+- IAM Managed Policy: Add support for ManagedPolicyName property [\#310](https://github.com/stevenjack/cfndsl/pull/310) ([mikechau](https://github.com/mikechau))
+
+## [v0.12.7](https://github.com/stevenjack/cfndsl/tree/v0.12.7) (2017-04-23)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.6...v0.12.7)
+
+**Merged pull requests:**
+
+- Add ssm param [\#307](https://github.com/stevenjack/cfndsl/pull/307) ([elmobp](https://github.com/elmobp))
+
+## [v0.12.6](https://github.com/stevenjack/cfndsl/tree/v0.12.6) (2017-04-21)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.5...v0.12.6)
+
+**Fixed bugs:**
+
+- AWS::SSM::Parameter support breaks cfndsl [\#308](https://github.com/stevenjack/cfndsl/issues/308)
+
+**Merged pull requests:**
+
+- add a globals class, and exclude reserverd words [\#309](https://github.com/stevenjack/cfndsl/pull/309) ([gergnz](https://github.com/gergnz))
+
+## [v0.12.5](https://github.com/stevenjack/cfndsl/tree/v0.12.5) (2017-04-10)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.4...v0.12.5)
+
+**Merged pull requests:**
+
+- Rubocop best practice change for %w literal delimitation [\#306](https://github.com/stevenjack/cfndsl/pull/306) ([AnominousSign](https://github.com/AnominousSign))
+- Add Amazon EFS type \(Elastic File System\) [\#305](https://github.com/stevenjack/cfndsl/pull/305) ([AnominousSign](https://github.com/AnominousSign))
+
+## [v0.12.4](https://github.com/stevenjack/cfndsl/tree/v0.12.4) (2017-03-29)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.3...v0.12.4)
+
+**Fixed bugs:**
+
+- fixes for rubocop 0.48 [\#302](https://github.com/stevenjack/cfndsl/pull/302) ([gergnz](https://github.com/gergnz))
+
+**Closed issues:**
+
+- Weird output in content section if string given to content doesn't end in new line [\#298](https://github.com/stevenjack/cfndsl/issues/298)
+- rake aborted! Seahorse::Client::NetworkingError:execution expired   [\#294](https://github.com/stevenjack/cfndsl/issues/294)
+
+**Merged pull requests:**
+
+- Add SSM Support [\#301](https://github.com/stevenjack/cfndsl/pull/301) ([elmobp](https://github.com/elmobp))
+
+## [v0.12.3](https://github.com/stevenjack/cfndsl/tree/v0.12.3) (2017-03-12)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.2...v0.12.3)
+
+**Closed issues:**
+
+- SQS Redrive policy - fix included. [\#295](https://github.com/stevenjack/cfndsl/issues/295)
+
+**Merged pull requests:**
+
+- Fix RedrivePolicy attributes [\#297](https://github.com/stevenjack/cfndsl/pull/297) ([devops-dude](https://github.com/devops-dude))
+
+## [v0.12.2](https://github.com/stevenjack/cfndsl/tree/v0.12.2) (2017-03-04)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.1...v0.12.2)
+
+**Closed issues:**
+
+- Rolename is missing from Role [\#291](https://github.com/stevenjack/cfndsl/issues/291)
+
+**Merged pull requests:**
+
+- add UserName property to IAM::User [\#293](https://github.com/stevenjack/cfndsl/pull/293) ([gergnz](https://github.com/gergnz))
+
+## [v0.12.1](https://github.com/stevenjack/cfndsl/tree/v0.12.1) (2017-02-21)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.12.0...v0.12.1)
+
+**Closed issues:**
+
+- Support for Serverless Application Model [\#273](https://github.com/stevenjack/cfndsl/issues/273)
+
+**Merged pull requests:**
+
+- updating IAM::Role and S3::Bucket types [\#292](https://github.com/stevenjack/cfndsl/pull/292) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.12.0](https://github.com/stevenjack/cfndsl/tree/v0.12.0) (2017-01-29)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.12...v0.12.0)
+
+**Merged pull requests:**
+
+- Added Serverless::Function & API Transforms [\#290](https://github.com/stevenjack/cfndsl/pull/290) ([jonjitsu](https://github.com/jonjitsu))
+
+## [v0.11.12](https://github.com/stevenjack/cfndsl/tree/v0.11.12) (2017-01-20)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.11...v0.11.12)
+
+**Implemented enhancements:**
+
+- Spot fleet support [\#282](https://github.com/stevenjack/cfndsl/issues/282)
+- add ipv6 to interfaces [\#284](https://github.com/stevenjack/cfndsl/pull/284) ([gergnz](https://github.com/gergnz))
+- Add support for spotfleet. Resolves \#282 [\#283](https://github.com/stevenjack/cfndsl/pull/283) ([gergnz](https://github.com/gergnz))
+
+**Closed issues:**
+
+- Error setting variable with '.' [\#288](https://github.com/stevenjack/cfndsl/issues/288)
+- Error specifying an SSL certificate when using an ALB [\#287](https://github.com/stevenjack/cfndsl/issues/287)
+- Hyphen in external parameter key throws obscure error  [\#286](https://github.com/stevenjack/cfndsl/issues/286)
+- Variable Number of Instances to a LoadBalancer [\#285](https://github.com/stevenjack/cfndsl/issues/285)
+- eval\_file\_with\_extras with ":raw" seems like it's trying to do two incompatible things [\#279](https://github.com/stevenjack/cfndsl/issues/279)
+
+**Merged pull requests:**
+
+- Added support for Fn::Split intrinsic function. [\#289](https://github.com/stevenjack/cfndsl/pull/289) ([pablovarela](https://github.com/pablovarela))
+
+## [v0.11.11](https://github.com/stevenjack/cfndsl/tree/v0.11.11) (2016-12-04)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.10...v0.11.11)
+
+**Closed issues:**
+
+- Support for environment variables in lambda functions [\#281](https://github.com/stevenjack/cfndsl/issues/281)
+
+**Merged pull requests:**
+
+- Add Environment as a property of Lambda::Function [\#280](https://github.com/stevenjack/cfndsl/pull/280) ([holmesjr](https://github.com/holmesjr))
+
+## [v0.11.10](https://github.com/stevenjack/cfndsl/tree/v0.11.10) (2016-11-23)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.9...v0.11.10)
+
+**Closed issues:**
+
+- ApplicationAutoScaling::ScalableTarget not supported. [\#270](https://github.com/stevenjack/cfndsl/issues/270)
+
+**Merged pull requests:**
+
+- Add Autoscaling NotificationConfiguration [\#275](https://github.com/stevenjack/cfndsl/pull/275) ([danielbergamin](https://github.com/danielbergamin))
+
+## [v0.11.9](https://github.com/stevenjack/cfndsl/tree/v0.11.9) (2016-11-18)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.8...v0.11.9)
+
+**Closed issues:**
+
+- Metadata in CFN Launch Config [\#268](https://github.com/stevenjack/cfndsl/issues/268)
+
+**Merged pull requests:**
+
+- Application Autoscaling Types [\#271](https://github.com/stevenjack/cfndsl/pull/271) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.11.8](https://github.com/stevenjack/cfndsl/tree/v0.11.8) (2016-11-13)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.6...v0.11.8)
+
+**Closed issues:**
+
+- Support for Export/Import values from stacks [\#260](https://github.com/stevenjack/cfndsl/issues/260)
+
+**Merged pull requests:**
+
+- Certificate manager type [\#267](https://github.com/stevenjack/cfndsl/pull/267) ([kornypoet](https://github.com/kornypoet))
+- Add monitoring properties to AWS::RDS::DBInstance [\#266](https://github.com/stevenjack/cfndsl/pull/266) ([mikechau](https://github.com/mikechau))
+- Add support for AWS::KMS::Alias [\#265](https://github.com/stevenjack/cfndsl/pull/265) ([mikechau](https://github.com/mikechau))
+
+## [v0.11.6](https://github.com/stevenjack/cfndsl/tree/v0.11.6) (2016-10-23)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.5...v0.11.6)
+
+**Implemented enhancements:**
+
+- Better test cases [\#16](https://github.com/stevenjack/cfndsl/issues/16)
+- Better documentation [\#15](https://github.com/stevenjack/cfndsl/issues/15)
+
+**Fixed bugs:**
+
+- No need to enforce this cop: this is a DSL [\#263](https://github.com/stevenjack/cfndsl/pull/263) ([kornypoet](https://github.com/kornypoet))
+
+**Merged pull requests:**
+
+- Add support for LogGroupName Property [\#262](https://github.com/stevenjack/cfndsl/pull/262) ([mikechau](https://github.com/mikechau))
+- Feature/add ecs task definition properties [\#261](https://github.com/stevenjack/cfndsl/pull/261) ([mikechau](https://github.com/mikechau))
+
+## [v0.11.5](https://github.com/stevenjack/cfndsl/tree/v0.11.5) (2016-10-05)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.4...v0.11.5)
+
+**Implemented enhancements:**
+
+- Support new function "Sub" [\#241](https://github.com/stevenjack/cfndsl/issues/241)
+
+**Merged pull requests:**
+
+- create fnsub branch, resolves \#244 and \#241 [\#258](https://github.com/stevenjack/cfndsl/pull/258) ([gergnz](https://github.com/gergnz))
+
+## [v0.11.4](https://github.com/stevenjack/cfndsl/tree/v0.11.4) (2016-10-05)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.3...v0.11.4)
+
+**Implemented enhancements:**
+
+- Support Import and Export of values for cross stack referencing [\#242](https://github.com/stevenjack/cfndsl/issues/242)
+- Support yaml as an output type option [\#240](https://github.com/stevenjack/cfndsl/issues/240)
+
+**Closed issues:**
+
+- Support Cloudformation's new YAML format. [\#254](https://github.com/stevenjack/cfndsl/issues/254)
+- Uninitialized constant CfnDsl::VERSION \(NameError\) [\#246](https://github.com/stevenjack/cfndsl/issues/246)
+
+**Merged pull requests:**
+
+- Add ECS ClusterName property to ECS Cluster type. [\#256](https://github.com/stevenjack/cfndsl/pull/256) ([pvdvreede](https://github.com/pvdvreede))
+- Update README.md [\#253](https://github.com/stevenjack/cfndsl/pull/253) ([herebebogans](https://github.com/herebebogans))
+- Function spec examples [\#251](https://github.com/stevenjack/cfndsl/pull/251) ([kornypoet](https://github.com/kornypoet))
+- Initial support for Cross stack references [\#249](https://github.com/stevenjack/cfndsl/pull/249) ([cmaxwellau](https://github.com/cmaxwellau))
+- This supports yaml as an output type and leaves json as the default [\#243](https://github.com/stevenjack/cfndsl/pull/243) ([gergnz](https://github.com/gergnz))
+
+## [v0.11.3](https://github.com/stevenjack/cfndsl/tree/v0.11.3) (2016-09-20)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.2...v0.11.3)
+
+**Merged pull requests:**
+
+- require cfndsl/version to prevent executable load errors [\#247](https://github.com/stevenjack/cfndsl/pull/247) ([kornypoet](https://github.com/kornypoet))
+- Add elastic search version [\#245](https://github.com/stevenjack/cfndsl/pull/245) ([ans0600](https://github.com/ans0600))
+- Fix for updated rubocop \(v 0.43.0\) [\#239](https://github.com/stevenjack/cfndsl/pull/239) ([gergnz](https://github.com/gergnz))
+- Update conditions.rb [\#238](https://github.com/stevenjack/cfndsl/pull/238) ([herebebogans](https://github.com/herebebogans))
+
+## [v0.11.2](https://github.com/stevenjack/cfndsl/tree/v0.11.2) (2016-09-19)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.1...v0.11.2)
+
+**Implemented enhancements:**
+
+- `FnNot` could be improved to not require array as the argument... [\#235](https://github.com/stevenjack/cfndsl/issues/235)
+- Provide support for AWS::CloudFormation::CustomResource [\#18](https://github.com/stevenjack/cfndsl/issues/18)
+- A couple of little things that were annoying me. [\#237](https://github.com/stevenjack/cfndsl/pull/237) ([gergnz](https://github.com/gergnz))
+- Improve FnNot method to not require ruby array. Fixes \#235 [\#236](https://github.com/stevenjack/cfndsl/pull/236) ([gergnz](https://github.com/gergnz))
+
+**Closed issues:**
+
+- DSL to JSON mapping not working [\#230](https://github.com/stevenjack/cfndsl/issues/230)
+- undefined method `LoadBalancer' [\#229](https://github.com/stevenjack/cfndsl/issues/229)
+
+**Merged pull requests:**
+
+- Add AccessLoggingPolicy to ELB [\#233](https://github.com/stevenjack/cfndsl/pull/233) ([gergnz](https://github.com/gergnz))
+
+## [v0.11.1](https://github.com/stevenjack/cfndsl/tree/v0.11.1) (2016-09-05)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.11.0...v0.11.1)
+
+**Closed issues:**
+
+- 0.11.0 removal of metadata has caused regression in existing templates [\#227](https://github.com/stevenjack/cfndsl/issues/227)
+
+**Merged pull requests:**
+
+- Add Kinesis Stream to AWS types  [\#228](https://github.com/stevenjack/cfndsl/pull/228) ([holmesjr](https://github.com/holmesjr))
+- standardise EC2Tag with ResourceTag [\#225](https://github.com/stevenjack/cfndsl/pull/225) ([gergnz](https://github.com/gergnz))
+- Simplecov [\#224](https://github.com/stevenjack/cfndsl/pull/224) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.11.0](https://github.com/stevenjack/cfndsl/tree/v0.11.0) (2016-08-25)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.10.2...v0.11.0)
+
+**Implemented enhancements:**
+
+- Orchestration template spec [\#213](https://github.com/stevenjack/cfndsl/pull/213) ([kornypoet](https://github.com/kornypoet))
+- Top Level Metadata [\#209](https://github.com/stevenjack/cfndsl/pull/209) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.10.2](https://github.com/stevenjack/cfndsl/tree/v0.10.2) (2016-08-25)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.10.1...v0.10.2)
+
+**Merged pull requests:**
+
+- Add SsmAssociations to EC2 Instance resource. [\#223](https://github.com/stevenjack/cfndsl/pull/223) ([pvdvreede](https://github.com/pvdvreede))
+
+## [v0.10.1](https://github.com/stevenjack/cfndsl/tree/v0.10.1) (2016-08-24)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.10.0...v0.10.1)
+
+**Merged pull requests:**
+
+- adding elasticache tags [\#216](https://github.com/stevenjack/cfndsl/pull/216) ([jstenhouse](https://github.com/jstenhouse))
+
+## [v0.10.0](https://github.com/stevenjack/cfndsl/tree/v0.10.0) (2016-08-22)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.9.5...v0.10.0)
+
+**Merged pull requests:**
+
+- remove method missing handlers [\#221](https://github.com/stevenjack/cfndsl/pull/221) ([kornypoet](https://github.com/kornypoet))
+- adding support for new application load balancers - AWS::ElasticLoadB… [\#220](https://github.com/stevenjack/cfndsl/pull/220) ([jstenhouse](https://github.com/jstenhouse))
+- Add GroupName property to IAM Group resource [\#219](https://github.com/stevenjack/cfndsl/pull/219) ([ampedandwired](https://github.com/ampedandwired))
+- Add KmsKeyId to the Redshift function. [\#217](https://github.com/stevenjack/cfndsl/pull/217) ([holmesjr](https://github.com/holmesjr))
+- Add EC2::FlowLog [\#215](https://github.com/stevenjack/cfndsl/pull/215) ([webdevwilson](https://github.com/webdevwilson))
+
+## [v0.9.5](https://github.com/stevenjack/cfndsl/tree/v0.9.5) (2016-07-26)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.9.4...v0.9.5)
+
+**Implemented enhancements:**
+
+- Plurals spec [\#212](https://github.com/stevenjack/cfndsl/pull/212) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.9.4](https://github.com/stevenjack/cfndsl/tree/v0.9.4) (2016-07-26)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.9.3...v0.9.4)
+
+**Implemented enhancements:**
+
+- Names spec [\#211](https://github.com/stevenjack/cfndsl/pull/211) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.9.3](https://github.com/stevenjack/cfndsl/tree/v0.9.3) (2016-07-26)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.9.2...v0.9.3)
+
+**Merged pull requests:**
+
+- AWS::WAF Type [\#208](https://github.com/stevenjack/cfndsl/pull/208) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.9.2](https://github.com/stevenjack/cfndsl/tree/v0.9.2) (2016-07-06)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.9.1...v0.9.2)
+
+**Fixed bugs:**
+
+- Cfndsl206 apigateway resource [\#207](https://github.com/stevenjack/cfndsl/pull/207) ([gergnz](https://github.com/gergnz))
+
+## [v0.9.1](https://github.com/stevenjack/cfndsl/tree/v0.9.1) (2016-06-22)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.9.0...v0.9.1)
+
+**Implemented enhancements:**
+
+- Remove List context for VpcSettings Datatype [\#204](https://github.com/stevenjack/cfndsl/pull/204) ([herebebogans](https://github.com/herebebogans))
+- Add Boolean for UseOpsworksSecurityGroups [\#203](https://github.com/stevenjack/cfndsl/pull/203) ([matthewrkrieger](https://github.com/matthewrkrieger))
+- Add RDS Event Subscription cloudformation resource. [\#202](https://github.com/stevenjack/cfndsl/pull/202) ([pvdvreede](https://github.com/pvdvreede))
+
+**Merged pull requests:**
+
+- Api gateway [\#201](https://github.com/stevenjack/cfndsl/pull/201) ([webdevwilson](https://github.com/webdevwilson))
+
+## [v0.9.0](https://github.com/stevenjack/cfndsl/tree/v0.9.0) (2016-06-22)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.9...v0.9.0)
+
+**Implemented enhancements:**
+
+- Exparams class methods [\#187](https://github.com/stevenjack/cfndsl/pull/187) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.8.9](https://github.com/stevenjack/cfndsl/tree/v0.8.9) (2016-06-02)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.8...v0.8.9)
+
+**Merged pull requests:**
+
+- Add Tags attribute to ELB [\#200](https://github.com/stevenjack/cfndsl/pull/200) ([webdevwilson](https://github.com/webdevwilson))
+
+## [v0.8.8](https://github.com/stevenjack/cfndsl/tree/v0.8.8) (2016-06-02)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.7...v0.8.8)
+
+**Merged pull requests:**
+
+- Add AWS RDS Option Group to types. [\#198](https://github.com/stevenjack/cfndsl/pull/198) ([pvdvreede](https://github.com/pvdvreede))
+
+## [v0.8.7](https://github.com/stevenjack/cfndsl/tree/v0.8.7) (2016-06-02)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.6...v0.8.7)
+
+**Implemented enhancements:**
+
+- Rubocop 0.40 Fixes [\#195](https://github.com/stevenjack/cfndsl/pull/195) ([gergnz](https://github.com/gergnz))
+- Update types.yaml - fixed tenancey typo [\#194](https://github.com/stevenjack/cfndsl/pull/194) ([johnhyland](https://github.com/johnhyland))
+
+## [v0.8.6](https://github.com/stevenjack/cfndsl/tree/v0.8.6) (2016-05-05)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.5...v0.8.6)
+
+**Implemented enhancements:**
+
+- Add yamlllint to Gemfile and add a rake task to lint all yaml files. [\#191](https://github.com/stevenjack/cfndsl/pull/191) ([gergnz](https://github.com/gergnz))
+
+**Merged pull requests:**
+
+- Adding MicrosoftAD to AWS types. [\#193](https://github.com/stevenjack/cfndsl/pull/193) ([pvdvreede](https://github.com/pvdvreede))
+
+## [v0.8.5](https://github.com/stevenjack/cfndsl/tree/v0.8.5) (2016-05-04)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.4...v0.8.5)
+
+**Implemented enhancements:**
+
+- Build stacks by including other ruby files [\#152](https://github.com/stevenjack/cfndsl/issues/152)
+- Osduplicatekey [\#192](https://github.com/stevenjack/cfndsl/pull/192) ([gergnz](https://github.com/gergnz))
+
+**Merged pull requests:**
+
+- Add cloudwatch events type [\#189](https://github.com/stevenjack/cfndsl/pull/189) ([gergnz](https://github.com/gergnz))
+
+## [v0.8.4](https://github.com/stevenjack/cfndsl/tree/v0.8.4) (2016-05-03)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.3...v0.8.4)
+
+**Merged pull requests:**
+
+- remove duplicate nat g/w definition [\#190](https://github.com/stevenjack/cfndsl/pull/190) ([gergnz](https://github.com/gergnz))
+
+## [v0.8.3](https://github.com/stevenjack/cfndsl/tree/v0.8.3) (2016-04-27)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.2...v0.8.3)
+
+**Fixed bugs:**
+
+- Add tag arguments [\#188](https://github.com/stevenjack/cfndsl/pull/188) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.8.2](https://github.com/stevenjack/cfndsl/tree/v0.8.2) (2016-04-27)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.1...v0.8.2)
+
+**Merged pull requests:**
+
+- Updated OpsWorks\_Stack to include ChefConfiguration [\#186](https://github.com/stevenjack/cfndsl/pull/186) ([webdevwilson](https://github.com/webdevwilson))
+
+## [v0.8.1](https://github.com/stevenjack/cfndsl/tree/v0.8.1) (2016-04-27)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.8.0...v0.8.1)
+
+**Merged pull requests:**
+
+- Add in Route53 Health Check Tags as a type [\#185](https://github.com/stevenjack/cfndsl/pull/185) ([gergnz](https://github.com/gergnz))
+
+## [v0.8.0](https://github.com/stevenjack/cfndsl/tree/v0.8.0) (2016-04-27)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.7.0...v0.8.0)
+
+**Implemented enhancements:**
+
+- Use as\_json instead of to\_json [\#157](https://github.com/stevenjack/cfndsl/pull/157) ([johnf](https://github.com/johnf))
+
+**Fixed bugs:**
+
+- Use as\\_json instead of to\\_json [\#157](https://github.com/stevenjack/cfndsl/pull/157) ([johnf](https://github.com/johnf))
+
+## [v0.7.0](https://github.com/stevenjack/cfndsl/tree/v0.7.0) (2016-04-27)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.6.2...v0.7.0)
+
+**Implemented enhancements:**
+
+- Fix the issue with plural types [\#153](https://github.com/stevenjack/cfndsl/pull/153) ([johnf](https://github.com/johnf))
+
+**Fixed bugs:**
+
+- Fix the issue with plural types [\#153](https://github.com/stevenjack/cfndsl/pull/153) ([johnf](https://github.com/johnf))
+
+## [v0.6.2](https://github.com/stevenjack/cfndsl/tree/v0.6.2) (2016-04-19)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.6.1...v0.6.2)
+
+**Implemented enhancements:**
+
+- Fix for \#181 - deprecation warning [\#182](https://github.com/stevenjack/cfndsl/pull/182) ([cmaxwellau](https://github.com/cmaxwellau))
+
+**Fixed bugs:**
+
+- Fix for \\#181 - deprecation warning [\#182](https://github.com/stevenjack/cfndsl/pull/182) ([cmaxwellau](https://github.com/cmaxwellau))
+
+**Closed issues:**
+
+- Deprecation warning with rake 11.1.2 [\#181](https://github.com/stevenjack/cfndsl/issues/181)
+
+## [v0.6.1](https://github.com/stevenjack/cfndsl/tree/v0.6.1) (2016-04-18)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.6.0...v0.6.1)
+
+**Implemented enhancements:**
+
+- External Parameters [\#170](https://github.com/stevenjack/cfndsl/issues/170)
+
+**Merged pull requests:**
+
+- Update types.yaml [\#180](https://github.com/stevenjack/cfndsl/pull/180) ([herebebogans](https://github.com/herebebogans))
+
+## [v0.6.0](https://github.com/stevenjack/cfndsl/tree/v0.6.0) (2016-04-18)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.5.2...v0.6.0)
+
+**Implemented enhancements:**
+
+- External params [\#179](https://github.com/stevenjack/cfndsl/pull/179) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.5.2](https://github.com/stevenjack/cfndsl/tree/v0.5.2) (2016-04-15)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.5.1...v0.5.2)
+
+**Fixed bugs:**
+
+- 5.0 release breaks addTag  [\#175](https://github.com/stevenjack/cfndsl/issues/175)
+- Remove erroneous logstream output [\#178](https://github.com/stevenjack/cfndsl/pull/178) ([stevenjack](https://github.com/stevenjack))
+
+## [v0.5.1](https://github.com/stevenjack/cfndsl/tree/v0.5.1) (2016-04-15)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.5.0...v0.5.1)
+
+**Implemented enhancements:**
+
+- Fix Rake task for bumping version number [\#173](https://github.com/stevenjack/cfndsl/pull/173) ([stevenjack](https://github.com/stevenjack))
+
+**Fixed bugs:**
+
+- JSON pretty printing for rake generated cloudformation [\#177](https://github.com/stevenjack/cfndsl/pull/177) ([cmaxwellau](https://github.com/cmaxwellau))
+
+**Closed issues:**
+
+- Pretty printing no longer working with Rake builds [\#176](https://github.com/stevenjack/cfndsl/issues/176)
+
+## [v0.5.0](https://github.com/stevenjack/cfndsl/tree/v0.5.0) (2016-04-13)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.4.4...v0.5.0)
+
+**Implemented enhancements:**
+
+- Code cleanup and improvments - Help needed [\#171](https://github.com/stevenjack/cfndsl/issues/171)
+- cfndsl\_examples [\#83](https://github.com/stevenjack/cfndsl/issues/83)
+- The Juno release of Openstack Heat has a whole new floatilla of resources [\#67](https://github.com/stevenjack/cfndsl/issues/67)
+- CLI Tests [\#169](https://github.com/stevenjack/cfndsl/pull/169) ([kornypoet](https://github.com/kornypoet))
+- Rubocop fixes [\#161](https://github.com/stevenjack/cfndsl/pull/161) ([stevenjack](https://github.com/stevenjack))
+
+## [v0.4.4](https://github.com/stevenjack/cfndsl/tree/v0.4.4) (2016-04-01)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.4.2...v0.4.4)
+
+**Closed issues:**
+
+- Updating aws\_types.yaml? [\#165](https://github.com/stevenjack/cfndsl/issues/165)
+
+## [v0.4.2](https://github.com/stevenjack/cfndsl/tree/v0.4.2) (2016-03-03)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.4.3...v0.4.2)
+
+## [v0.4.3](https://github.com/stevenjack/cfndsl/tree/v0.4.3) (2016-03-01)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.4.1...v0.4.3)
+
+**Closed issues:**
+
+- Support the Elasticsearch Service [\#155](https://github.com/stevenjack/cfndsl/issues/155)
+
+## [v0.4.1](https://github.com/stevenjack/cfndsl/tree/v0.4.1) (2016-02-18)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.4.0...v0.4.1)
+
+## [v0.4.0](https://github.com/stevenjack/cfndsl/tree/v0.4.0) (2016-02-11)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.3.6...v0.4.0)
+
+## [v0.3.6](https://github.com/stevenjack/cfndsl/tree/v0.3.6) (2016-02-09)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.3.5...v0.3.6)
+
+**Implemented enhancements:**
+
+- Pretty-formatted multi-line output JSON [\#149](https://github.com/stevenjack/cfndsl/issues/149)
+
+## [v0.3.5](https://github.com/stevenjack/cfndsl/tree/v0.3.5) (2016-02-03)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.3.4...v0.3.5)
+
+## [v0.3.4](https://github.com/stevenjack/cfndsl/tree/v0.3.4) (2016-01-28)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.3.3...v0.3.4)
+
+**Merged pull requests:**
+
+- add AutoScalingConfiguration missing property [\#144](https://github.com/stevenjack/cfndsl/pull/144) ([kornypoet](https://github.com/kornypoet))
+
+## [v0.3.3](https://github.com/stevenjack/cfndsl/tree/v0.3.3) (2015-12-26)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.3.2...v0.3.3)
+
+**Closed issues:**
+
+- Add support for additional RDS properties [\#142](https://github.com/stevenjack/cfndsl/issues/142)
+- Add support for KMS::Key [\#140](https://github.com/stevenjack/cfndsl/issues/140)
+
+## [v0.3.2](https://github.com/stevenjack/cfndsl/tree/v0.3.2) (2015-11-20)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.3.1...v0.3.2)
+
+**Merged pull requests:**
+
+- json gem required [\#136](https://github.com/stevenjack/cfndsl/pull/136) ([erikmack](https://github.com/erikmack))
+- Ensure last value wins when a Property is set multiple times [\#135](https://github.com/stevenjack/cfndsl/pull/135) ([erikmack](https://github.com/erikmack))
+- Fix typo in return type [\#134](https://github.com/stevenjack/cfndsl/pull/134) ([erikmack](https://github.com/erikmack))
+- Update t1.rb template to match README text [\#132](https://github.com/stevenjack/cfndsl/pull/132) ([nickjwebb](https://github.com/nickjwebb))
+- Enable NotificationConfigurations on S3 Bucket object [\#131](https://github.com/stevenjack/cfndsl/pull/131) ([webdevwilson](https://github.com/webdevwilson))
+
+## [v0.3.1](https://github.com/stevenjack/cfndsl/tree/v0.3.1) (2015-10-29)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.9...v0.3.1)
+
+## [v0.2.9](https://github.com/stevenjack/cfndsl/tree/v0.2.9) (2015-10-29)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.8...v0.2.9)
+
+## [v0.2.8](https://github.com/stevenjack/cfndsl/tree/v0.2.8) (2015-10-29)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.7...v0.2.8)
+
+## [v0.2.7](https://github.com/stevenjack/cfndsl/tree/v0.2.7) (2015-10-14)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.4...v0.2.7)
+
+## [v0.2.4](https://github.com/stevenjack/cfndsl/tree/v0.2.4) (2015-09-29)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.3.0...v0.2.4)
+
+## [v0.3.0](https://github.com/stevenjack/cfndsl/tree/v0.3.0) (2015-09-29)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.3...v0.3.0)
+
+## [v0.2.3](https://github.com/stevenjack/cfndsl/tree/v0.2.3) (2015-08-26)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.2...v0.2.3)
+
+**Closed issues:**
+
+- Undefined symbol: EC2MountPoint - possible issue? [\#124](https://github.com/stevenjack/cfndsl/issues/124)
+
+## [v0.2.2](https://github.com/stevenjack/cfndsl/tree/v0.2.2) (2015-08-10)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.1...v0.2.2)
+
+## [v0.2.1](https://github.com/stevenjack/cfndsl/tree/v0.2.1) (2015-08-10)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.2.0...v0.2.1)
+
+## [v0.2.0](https://github.com/stevenjack/cfndsl/tree/v0.2.0) (2015-08-10)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.20...v0.2.0)
+
+**Closed issues:**
+
+- Add support for IAM::Group ManagedPolicyArns [\#119](https://github.com/stevenjack/cfndsl/issues/119)
+
+## [v0.1.20](https://github.com/stevenjack/cfndsl/tree/v0.1.20) (2015-07-22)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.19...v0.1.20)
+
+**Closed issues:**
+
+- Add support for IAM::Role ManagedPolicyArns [\#114](https://github.com/stevenjack/cfndsl/issues/114)
+- aws\_types.aws AWS::SQS::Queue missing property QueueName: String [\#108](https://github.com/stevenjack/cfndsl/issues/108)
+
+## [v0.1.19](https://github.com/stevenjack/cfndsl/tree/v0.1.19) (2015-07-16)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.18...v0.1.19)
+
+**Closed issues:**
+
+- SecurityGroupIngress/Egress formatting with additional \[\] [\#109](https://github.com/stevenjack/cfndsl/issues/109)
+
+## [v0.1.18](https://github.com/stevenjack/cfndsl/tree/v0.1.18) (2015-06-22)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.17...v0.1.18)
+
+## [v0.1.17](https://github.com/stevenjack/cfndsl/tree/v0.1.17) (2015-06-22)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.16...v0.1.17)
+
+## [v0.1.16](https://github.com/stevenjack/cfndsl/tree/v0.1.16) (2015-06-15)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.15...v0.1.16)
+
+**Fixed bugs:**
+
+- PreferredAvailabilityZone Property on ElastiCache\_CacheCluster is incorrect [\#92](https://github.com/stevenjack/cfndsl/issues/92)
+
+## [v0.1.15](https://github.com/stevenjack/cfndsl/tree/v0.1.15) (2015-05-10)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.14...v0.1.15)
+
+**Closed issues:**
+
+- Oddity where do/end block breaks expectations, but {} works fine? [\#86](https://github.com/stevenjack/cfndsl/issues/86)
+
+## [v0.1.14](https://github.com/stevenjack/cfndsl/tree/v0.1.14) (2015-04-24)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.11...v0.1.14)
+
+**Implemented enhancements:**
+
+- Alert user if they've incorrectly capitialized the function name [\#84](https://github.com/stevenjack/cfndsl/pull/84) ([stevenjack](https://github.com/stevenjack))
+
+**Merged pull requests:**
+
+- Redshift [\#87](https://github.com/stevenjack/cfndsl/pull/87) ([kornypoet](https://github.com/kornypoet))
+- Add Route53::HostedZone and Route53::HealthCheck [\#85](https://github.com/stevenjack/cfndsl/pull/85) ([benley](https://github.com/benley))
+
+## [v0.1.11](https://github.com/stevenjack/cfndsl/tree/v0.1.11) (2015-02-05)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.10...v0.1.11)
+
+**Implemented enhancements:**
+
+- "AWS::SNS::Topic" does not appear to be fully defined [\#81](https://github.com/stevenjack/cfndsl/issues/81)
+
+## [v0.1.10](https://github.com/stevenjack/cfndsl/tree/v0.1.10) (2015-01-19)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.9...v0.1.10)
+
+## [v0.1.9](https://github.com/stevenjack/cfndsl/tree/v0.1.9) (2015-01-13)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.8...v0.1.9)
+
+**Closed issues:**
+
+- Add some better support for base64 in FnFormat [\#66](https://github.com/stevenjack/cfndsl/issues/66)
+
+**Merged pull requests:**
+
+- Fixes a typo in cfndsl.rb that was causing an error when in verbose mode... [\#76](https://github.com/stevenjack/cfndsl/pull/76) ([scottabutler](https://github.com/scottabutler))
+
+## [v0.1.8](https://github.com/stevenjack/cfndsl/tree/v0.1.8) (2015-01-02)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.7...v0.1.8)
+
+## [v0.1.7](https://github.com/stevenjack/cfndsl/tree/v0.1.7) (2014-12-26)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.3...v0.1.7)
+
+**Closed issues:**
+
+- Support for userData Script [\#57](https://github.com/stevenjack/cfndsl/issues/57)
+- The AWS Resource AWS::EC2::NetworkInterface is missing [\#54](https://github.com/stevenjack/cfndsl/issues/54)
+- Add support for Openstack Heat [\#33](https://github.com/stevenjack/cfndsl/issues/33)
+- Self-referencing SecurityGroups [\#32](https://github.com/stevenjack/cfndsl/issues/32)
+- CloudFormation output ordering doesn't match order of cfndsl template [\#26](https://github.com/stevenjack/cfndsl/issues/26)
+- Limited Validatation of Resource Property Data Types [\#4](https://github.com/stevenjack/cfndsl/issues/4)
+
+**Merged pull requests:**
+
+- typo [\#69](https://github.com/stevenjack/cfndsl/pull/69) ([tbenade](https://github.com/tbenade))
+- Add support for OpsWorks types [\#64](https://github.com/stevenjack/cfndsl/pull/64) ([benley](https://github.com/benley))
+- Made some changes to aws\_types.yaml to try to keep up with changes made ... [\#62](https://github.com/stevenjack/cfndsl/pull/62) ([howech](https://github.com/howech))
+- Add support for ConnectionDrainingPolicy [\#61](https://github.com/stevenjack/cfndsl/pull/61) ([josephglanville](https://github.com/josephglanville))
+- Add some missing properties of numerous resources [\#60](https://github.com/stevenjack/cfndsl/pull/60) ([josephglanville](https://github.com/josephglanville))
+- Added some command line options to affect the behavior of cfndsl. [\#59](https://github.com/stevenjack/cfndsl/pull/59) ([howech](https://github.com/howech))
+- Add some nominal support for Openstack Heat [\#58](https://github.com/stevenjack/cfndsl/pull/58) ([howech](https://github.com/howech))
+- Eval context [\#56](https://github.com/stevenjack/cfndsl/pull/56) ([howech](https://github.com/howech))
+- Add NetworkInterface resource Closes \#54 [\#55](https://github.com/stevenjack/cfndsl/pull/55) ([erikmack](https://github.com/erikmack))
+
+## [v0.1.3](https://github.com/stevenjack/cfndsl/tree/v0.1.3) (2014-07-02)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.2...v0.1.3)
+
+**Fixed bugs:**
+
+- fixed a typo in SourceSecurityGroupName and SourceSecurityGroupId [\#51](https://github.com/stevenjack/cfndsl/pull/51) ([howech](https://github.com/howech))
+
+**Closed issues:**
+
+- Output to a string instead of STDOUT? [\#23](https://github.com/stevenjack/cfndsl/issues/23)
+
+## [v0.1.2](https://github.com/stevenjack/cfndsl/tree/v0.1.2) (2014-05-28)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.1...v0.1.2)
+
+**Closed issues:**
+
+- Publish Updated Gem? [\#50](https://github.com/stevenjack/cfndsl/issues/50)
+
+## [v0.1.1](https://github.com/stevenjack/cfndsl/tree/v0.1.1) (2014-05-14)
+[Full Changelog](https://github.com/stevenjack/cfndsl/compare/v0.1.0...v0.1.1)
+
+**Closed issues:**
+
+- License missing from gemspec [\#21](https://github.com/stevenjack/cfndsl/issues/21)
+
+**Merged pull requests:**
+
+- Change license to MIT and update gemfile [\#48](https://github.com/stevenjack/cfndsl/pull/48) ([stevenjack](https://github.com/stevenjack))
+
+## [v0.1.0](https://github.com/stevenjack/cfndsl/tree/v0.1.0) (2014-05-13)
+**Implemented enhancements:**
+
+- Adds missing Pseudo Parameters [\#40](https://github.com/stevenjack/cfndsl/pull/40) ([stevenjack](https://github.com/stevenjack))
+- ASG update policy [\#38](https://github.com/stevenjack/cfndsl/pull/38) ([k-ong](https://github.com/k-ong))
+- Added FnSelect function to JSONable.rb [\#36](https://github.com/stevenjack/cfndsl/pull/36) ([louism517](https://github.com/louism517))
+- Adding new properties to various resources [\#35](https://github.com/stevenjack/cfndsl/pull/35) ([ianneub](https://github.com/ianneub))
+
+**Closed issues:**
+
+- Add support for UpdatePolicy on AutoScalingGroups [\#34](https://github.com/stevenjack/cfndsl/issues/34)
+- One cfndsl file =\> multiple Cloudformation templates [\#29](https://github.com/stevenjack/cfndsl/issues/29)
+- Errors on Mac 10.8.4, using version installed with 'gem install cfndsl' [\#25](https://github.com/stevenjack/cfndsl/issues/25)
+- Requesting cfndsl example based on this AWS example template [\#24](https://github.com/stevenjack/cfndsl/issues/24)
+- Feature Request: Support for "AWS::CloudFormation::Init" and "AWS::CloudFormation::Authentication" Types [\#17](https://github.com/stevenjack/cfndsl/issues/17)
+- Unify implementations of singular/plural methods for array properties [\#13](https://github.com/stevenjack/cfndsl/issues/13)
+- Better way to tag Instances [\#11](https://github.com/stevenjack/cfndsl/issues/11)
+- Format identifiers [\#9](https://github.com/stevenjack/cfndsl/issues/9)
+- Add Properties syntax for Resources [\#8](https://github.com/stevenjack/cfndsl/issues/8)
+- Set up the cfn-init metadata to work like resources [\#7](https://github.com/stevenjack/cfndsl/issues/7)
+- Better Error Handling via method\_missing [\#6](https://github.com/stevenjack/cfndsl/issues/6)
+- Data driven type specifier [\#5](https://github.com/stevenjack/cfndsl/issues/5)
+- Validate Resource Property Names [\#3](https://github.com/stevenjack/cfndsl/issues/3)
+- Validate Resource Types [\#2](https://github.com/stevenjack/cfndsl/issues/2)
+
+**Merged pull requests:**
+
+- Updates test script to use correct load balancer names property [\#47](https://github.com/stevenjack/cfndsl/pull/47) ([stevenjack](https://github.com/stevenjack))
+- Adds bundler tasks to ease testing gem and releasing [\#46](https://github.com/stevenjack/cfndsl/pull/46) ([stevenjack](https://github.com/stevenjack))
+- Asg update policy [\#45](https://github.com/stevenjack/cfndsl/pull/45) ([stevenjack](https://github.com/stevenjack))
+- Add conditions [\#44](https://github.com/stevenjack/cfndsl/pull/44) ([stevenjack](https://github.com/stevenjack))
+- Don't exit - write error to STDERR [\#43](https://github.com/stevenjack/cfndsl/pull/43) ([stevenjack](https://github.com/stevenjack))
+- Travis integration [\#42](https://github.com/stevenjack/cfndsl/pull/42) ([stevenjack](https://github.com/stevenjack))
+- Corrected GetAtt typo. Edit doesn't appear to alter output. [\#31](https://github.com/stevenjack/cfndsl/pull/31) ([josh-wrale](https://github.com/josh-wrale))
+- Fixed incomplete 'GroupName' property for AWS::IAM::UserToGroupAddition [\#30](https://github.com/stevenjack/cfndsl/pull/30) ([josh-wrale](https://github.com/josh-wrale))
+- IAM Additions and Small Corrections and/or Improvements [\#28](https://github.com/stevenjack/cfndsl/pull/28) ([josh-wrale](https://github.com/josh-wrale))
+- Added IamInstanceProfile to EC2::Instance type. [\#27](https://github.com/stevenjack/cfndsl/pull/27) ([ianneub](https://github.com/ianneub))
+- Changing AliasTarget property to be a single AliasTarget, and not an array of them. [\#22](https://github.com/stevenjack/cfndsl/pull/22) ([ianneub](https://github.com/ianneub))
+- Clean up the Listener property type [\#20](https://github.com/stevenjack/cfndsl/pull/20) ([ianneub](https://github.com/ianneub))
+- Reimplmenented property methods as outlined in issue \#13 [\#14](https://github.com/stevenjack/cfndsl/pull/14) ([howech](https://github.com/howech))
+- Added resources definitions related to VPC [\#12](https://github.com/stevenjack/cfndsl/pull/12) ([liguorien](https://github.com/liguorien))
+- Added a Tag function [\#10](https://github.com/stevenjack/cfndsl/pull/10) ([liguorien](https://github.com/liguorien))
+- Update supported pseudo parameters [\#1](https://github.com/stevenjack/cfndsl/pull/1) ([radim](https://github.com/radim))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem 'json'
 
 group :development, :test do
+  gem 'github_changelog_generator', require: false
   gem 'rubocop', require: false
   gem 'yamllint', require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,6 @@ end
 
 task default: %i[spec rubocop yamllint]
 
-GitHubChangelogGenerator::RakeTask.new :changelog
-
 task :bump, :type do |_, args|
   type = args[:type].downcase
   version_path = 'lib/cfndsl/version.rb'
@@ -51,9 +49,14 @@ task :bump, :type do |_, args|
 
   version = version_segments.join('.')
 
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    config.release_url = 'https://rubygems.org/gems/cfndsl/versions/%s'
+    config.future_release = version
+  end
+
   puts "Bumping gem from version #{CfnDsl::VERSION} to #{version} as a '#{type.capitalize}' release"
 
-  puts "Warning, CHANGELOG_GITHUB_TOKEN is unset, you will likely be rate limited" if ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+  puts 'Warning, CHANGELOG_GITHUB_TOKEN is unset, you will likely be rate limited' if ENV['CHANGELOG_GITHUB_TOKEN'].nil?
   Rake::Task[:changelog].execute
 
   contents         = File.read version_path


### PR DESCRIPTION
Taking a stab at #299.

Generated a changelog with [github-changelog-generator](https://github.com/skywinder/github-changelog-generator).

Included the gem in case you guys wanted to make it part of your deploy process. But I can remove it if you'd prefer to not include it.

cc: @kidbrax @kornypoet 