### PR TITLE
Remove release_url config from github changelog generator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,6 @@ task :bump, :type do |_, args|
   version = version_segments.join('.')
 
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.release_url = 'https://rubygems.org/gems/cfndsl/versions/%s'
     config.future_release = version
   end
 


### PR DESCRIPTION
I've updated the github changelog config to remove the `release_url` config... due to this issue: https://github.com/skywinder/github-changelog-generator/issues/326

This commit reverts the release links in the changelog back to github releases as github-changelog-generator currently does not have a mechanism to strip the `v` from the git tag.