### PR TITLE
IAM::InstanceProfile: add InstanceProfileName property #317

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -713,6 +713,7 @@ Resources:
    Properties:
     Path: String
     Roles: [ String ]
+    InstanceProfileName: String
    Attributes:
     Arn : String
   "AWS::IAM::ManagedPolicy" :

--- a/spec/aws/iam_instance_profile_spec.rb
+++ b/spec/aws/iam_instance_profile_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CfnDsl::CloudFormationTemplate do
+  subject(:template) { described_class.new }
+
+  describe '#IAM_InstanceProfile' do
+    it 'supports InstanceProfileName property' do
+      template.IAM_InstanceProfile(:TestPolicy) do
+        InstanceProfileName 'instance-profile-name'
+      end
+
+      expect(template.to_json).to include('"InstanceProfileName":"instance-profile-name"')
+    end
+  end
+end


### PR DESCRIPTION
Updated `IAM::InsanceProfile` to support the `InstanceProfileName` property.

Properties supported as of **(5/14/17)**:

```yaml
Type: "AWS::IAM::InstanceProfile"
Properties: 
  Path: String
  Roles:
    - IAM Roles 
  InstanceProfileName: String
```

Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html

#317 