### PR TITLE
Fallback to included resource spec if not overridden

### DIFF
--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -72,7 +72,7 @@ end
 
 optparse.parse!
 
-if !File.exist?(CfnDsl.specification_file) || options[:update_spec]
+if options[:update_spec]
   STDERR.puts 'Updating specification file'
   FileUtils.mkdir_p File.dirname(CfnDsl.specification_file)
   content = open('https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json').read

--- a/lib/cfndsl/specification.rb
+++ b/lib/cfndsl/specification.rb
@@ -79,8 +79,13 @@ module CfnDsl
       end
     end
 
+    def self.determine_spec_file
+      return CfnDsl.specification_file if File.exist? CfnDsl.specification_file
+      File.expand_path('../aws/resource_specification.json', __FILE__)
+    end
+
     def self.extract_from_resource_spec!
-      spec_file = JSON.parse File.read(CfnDsl.specification_file)
+      spec_file = JSON.parse File.read(determine_spec_file)
       resources = extract_resources spec_file['ResourceTypes'].merge(Patches.resources)
       types = extract_types spec_file['PropertyTypes'].merge(Patches.types)
       { 'Resources' => resources, 'Types' => types }


### PR DESCRIPTION
The logic should be as follows:
* The cli allows you to download an updated resource specification file (using the `-u` flag)
* The cli allows you to override the resource specification file (using the `-s` flag)
* The cli will _not_ force you to update to a local resource specification file by default
* Using the internal api, you can override the resource specification file (using `CfnDsl.specification_file('/path/to/file')`
* The code will honor `CfnDsl.specification_file` if it is set by either the cli or the internal api first. If unset, it then looks for `~/.cfndsl/resource_specification.json`. Lastly, it will fall back to the included (but possibly outdated) resource specification bundled in the repo.