### PR TITLE
Update types.yaml to add IamRoles parameter to AWS::Redshift::Cluster

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -960,6 +960,7 @@ Resources:
       Encrypted: Boolean
       HsmClientCertificateIdentifier: String
       HsmConfigurationIdentifier: String
+      IamRoles: [ String ]
       KmsKeyId: String
       MasterUsername: String
       MasterUserPassword: String


### PR DESCRIPTION
This pull request is to add the IamRoles parameter to AWS::Redshift::Cluster in types.yaml.