### PR TITLE
Fix parameter parsing when its value contains equal symbol

### DIFF
--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -74,7 +74,8 @@ module CfnDsl
           b.eval(File.read(file), file)
         end
       when :raw
-        params.set_param(*file.split('='))
+        file_parts = file.split("=")
+        params.set_param(file_parts[0],file_parts[1..-1].join("="))
         unless disable_binding?
           logstream.puts("Running raw ruby code #{file}") if logstream
           b.eval(file, 'raw code')

--- a/spec/fixtures/test.rb
+++ b/spec/fixtures/test.rb
@@ -16,6 +16,11 @@ CloudFormation do
     MaxLength 15
   end
 
+  Parameter('Three') do
+    String
+    Default external_parameters[:three]
+  end
+
   # Condition Function examples
   Condition('OneIsTest', FnEquals(Ref('One'), 'Test'))
   Condition('OneIsNotTest', FnNot(FnEquals(Ref('One'), 'Test')))


### PR DESCRIPTION
Make sure external parameter is set correctly when its value contains "="