### PR TITLE
Add type patch for AWS::SSM::PatchBaseline.PatchGroup

### DIFF
--- a/lib/cfndsl/patches.rb
+++ b/lib/cfndsl/patches.rb
@@ -91,6 +91,11 @@ module CfnDsl
           'Properties' => {
             'Rules' => { 'Type' => 'List', 'ItemType' => 'MappingRule' }
           }
+        },
+        'AWS::SSM::PatchBaseline.PatchGroup' => {
+          'Properties' => {
+            'Type' => { 'PrimitiveType' => 'String' }
+          }
         }
       }
     end


### PR DESCRIPTION
The latest CFN template spec (v1.8.0) defines the `PrimitiveType` for `AWS::SSM::PatchBaseline.PatchGroup` in the wrong way.  Add a type patch to resolve the inconsistency.

Without this, cfndsl spits out the following error upon execution: `NameError: uninitialized constant CfnDsl::AWS::Types::AWSSSMPatchBaselinePatchGroup`

v1.8.0 spec:

```json
  "AWS::SSM::PatchBaseline.PatchGroup": {
    "PrimitiveType": "String"
  }
```

Expected format (the patch):

```json
  "AWS::SSM::PatchBaseline.PatchGroup": {
    "Properties": {
      "Type": { "PrimitiveType": "String" }
    }
  }
```
