### PR TITLE
Fix ResourceDefinition#add_tag

### DIFF
--- a/lib/cfndsl/resources.rb
+++ b/lib/cfndsl/resources.rb
@@ -8,15 +8,14 @@ module CfnDsl
     dsl_attr_setter :Type, :DependsOn, :DeletionPolicy, :Condition, :Metadata
     dsl_content_object :Property, :UpdatePolicy, :CreationPolicy
 
-    def addTag(name, value, propagate = nil)
-      add_tag(name, value, propagate)
+    def addTag(name, value)
+      add_tag(name, value)
     end
 
-    def add_tag(name, value, propagate = nil)
+    def add_tag(name, value)
       send(:Tag) do
         Key name
         Value value
-        PropagateAtLaunch propagate unless propagate.nil?
       end
     end
 

--- a/spec/resources_spec.rb
+++ b/spec/resources_spec.rb
@@ -1,24 +1,23 @@
 require 'spec_helper'
 
 describe CfnDsl::ResourceDefinition do
-  subject { CfnDsl::CloudFormationTemplate.new.AutoScalingGroup(:web_servers) }
+  subject { CfnDsl::CloudFormationTemplate.new.EC2_Instance(:web_server) }
 
   context '#addTag' do
     it 'is a pass-through method to add_tag' do
-      expect(subject).to receive(:add_tag).with('role', 'web-server', true)
-      subject.addTag('role', 'web-server', true)
+      expect(subject).to receive(:add_tag).with('role', 'web-server')
+      subject.addTag('role', 'web-server')
     end
   end
 
   context '#add_tag' do
     it 'adds a Tag for the resource' do
-      subject.add_tag('role', 'web-server', true)
+      subject.add_tag('role', 'web-server')
       tags = subject.Property(:Tags).value
       expect(tags).to be_an(Array)
       tag = tags.pop
       expect(tag.instance_variable_get('@Key')).to eq('role')
       expect(tag.instance_variable_get('@Value')).to eq('web-server')
-      expect(tag.instance_variable_get('@PropagateAtLaunch')).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Fix ResourceDefinition#add_tag.  The method and corresponding spec were mixing handling of generic resource tags and ASG tags.  Generic resource tags are of `ItemType Tag`, while AutoScalingGroup tags are of `ItemType AutoScalingGroup.TagProperty`.  The former are shared by multiple resource types and support only the `Key` and `Value` properties.  The latter is specific to AutoScalingGroups and adds the `PropagateAtLaunch` property.  Since ResourceDefinition#add_tag appears to be general purpose, I updated to reflect reality for generic resource tags.

On its own, this change would break cases where someone is using `#add_tag` on an AutoScalingGroup.  However, it turns out the CFN service team [renamed](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-tags) the ASG `Tags` property to `AsTags` in the latest resource specification release, which _already_ breaks cases where `#addTag` was called on an AutoScalingGroup, as the resource no longer has a corresponding `Tags` property.

Related: https://travis-ci.org/stevenjack/cfndsl/builds/296805147?utm_source=github_status&utm_medium=notification (spec failure using latest resource spec file).